### PR TITLE
Guard against null ResultSet in EnvironmentRepositoryImpl

### DIFF
--- a/src/main/java/preponderous/viron/repositories/EnvironmentRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/EnvironmentRepositoryImpl.java
@@ -26,6 +26,10 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
     public List<Environment> findAll() {
         List<Environment> environments = new ArrayList<>();
         ResultSet rs = dbInteractions.query("SELECT * FROM viron.environment");
+        if (rs == null) {
+            log.error("Error finding all environments: ResultSet is null");
+            return environments;
+        }
         try {
             while (rs.next()) {
                 environments.add(mapResultSetToEnvironment(rs));
@@ -39,6 +43,10 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
     @Override
     public Optional<Environment> findById(int id) {
         ResultSet rs = dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = " + id);
+        if (rs == null) {
+            log.error("Error finding environment by id: ResultSet is null");
+            return Optional.empty();
+        }
         try {
             if (rs.next()) {
                 return Optional.of(mapResultSetToEnvironment(rs));
@@ -52,6 +60,10 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
     @Override
     public Optional<Environment> findByName(String name) {
         ResultSet rs = dbInteractions.query("SELECT * FROM viron.environment WHERE name = '" + name + "'");
+        if (rs == null) {
+            log.error("Error finding environment by name: ResultSet is null");
+            return Optional.empty();
+        }
         try {
             if (rs.next()) {
                 return Optional.of(mapResultSetToEnvironment(rs));
@@ -65,6 +77,10 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
     @Override
     public Optional<Environment> findByEntityId(int entityId) {
         ResultSet rs = dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")");
+        if (rs == null) {
+            log.error("Error finding environment by entity id: ResultSet is null");
+            return Optional.empty();
+        }
         try {
             if (rs.next()) {
                 return Optional.of(mapResultSetToEnvironment(rs));
@@ -96,6 +112,10 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
     public List<Integer> findEntityIdsByEnvironmentId(int environmentId) {
         List<Integer> entityIds = new ArrayList<>();
         ResultSet rs = dbInteractions.query("SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))");
+        if (rs == null) {
+            log.error("Error finding entity ids: ResultSet is null");
+            return entityIds;
+        }
         try {
             while (rs.next()) {
                 entityIds.add(rs.getInt("entity_id"));
@@ -110,6 +130,10 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
     public List<Integer> findLocationIdsByEnvironmentId(int environmentId) {
         List<Integer> locationIds = new ArrayList<>();
         ResultSet rs = dbInteractions.query("SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")");
+        if (rs == null) {
+            log.error("Error finding location ids: ResultSet is null");
+            return locationIds;
+        }
         try {
             while (rs.next()) {
                 locationIds.add(rs.getInt("location_id"));
@@ -124,6 +148,10 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
     public List<Integer> findGridIdsByEnvironmentId(int environmentId) {
         List<Integer> gridIds = new ArrayList<>();
         ResultSet rs = dbInteractions.query("SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId);
+        if (rs == null) {
+            log.error("Error finding grid ids: ResultSet is null");
+            return gridIds;
+        }
         try {
             while (rs.next()) {
                 gridIds.add(rs.getInt("grid_id"));

--- a/src/test/java/preponderous/viron/repositories/EnvironmentRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/EnvironmentRepositoryImplTest.java
@@ -14,9 +14,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-// Note: unlike its sibling repositories, EnvironmentRepositoryImpl does not guard
-// against a null ResultSet, so null-ResultSet cases are intentionally not exercised
-// here (they currently throw NullPointerException). Tracked separately.
 @SpringBootTest
 public class EnvironmentRepositoryImplTest {
 
@@ -65,6 +62,17 @@ public class EnvironmentRepositoryImplTest {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
         Mockito.when(dbInteractions.query("SELECT * FROM viron.environment")).thenReturn(mockResultSet);
         Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
+
+        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
+
+        List<Environment> result = repository.findAll();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testFindAll_ReturnsEmptyListWhenResultSetIsNull() {
+        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment")).thenReturn(null);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -123,6 +131,18 @@ public class EnvironmentRepositoryImplTest {
         assertThat(result).isEmpty();
     }
 
+    @Test
+    public void testFindById_ReturnsEmptyWhenResultSetIsNull() {
+        int id = 1;
+        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = " + id)).thenReturn(null);
+
+        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
+
+        Optional<Environment> result = repository.findById(id);
+
+        assertThat(result).isEmpty();
+    }
+
     // ---- findByName ----
 
     @Test
@@ -173,6 +193,18 @@ public class EnvironmentRepositoryImplTest {
         assertThat(result).isEmpty();
     }
 
+    @Test
+    public void testFindByName_ReturnsEmptyWhenResultSetIsNull() {
+        String name = "Env1";
+        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE name = '" + name + "'")).thenReturn(null);
+
+        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
+
+        Optional<Environment> result = repository.findByName(name);
+
+        assertThat(result).isEmpty();
+    }
+
     // ---- findByEntityId ----
 
     @Test
@@ -215,6 +247,18 @@ public class EnvironmentRepositoryImplTest {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
         Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")")).thenReturn(mockResultSet);
         Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
+
+        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
+
+        Optional<Environment> result = repository.findByEntityId(entityId);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testFindByEntityId_ReturnsEmptyWhenResultSetIsNull() {
+        int entityId = 7;
+        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")")).thenReturn(null);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -331,6 +375,19 @@ public class EnvironmentRepositoryImplTest {
         assertThat(result).isEmpty();
     }
 
+    @Test
+    public void testFindEntityIdsByEnvironmentId_ReturnsEmptyListWhenResultSetIsNull() {
+        int environmentId = 5;
+        String query = "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))";
+        Mockito.when(dbInteractions.query(query)).thenReturn(null);
+
+        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
+
+        List<Integer> result = repository.findEntityIdsByEnvironmentId(environmentId);
+
+        assertThat(result).isEmpty();
+    }
+
     // ---- findLocationIdsByEnvironmentId ----
 
     @Test
@@ -379,6 +436,19 @@ public class EnvironmentRepositoryImplTest {
         assertThat(result).isEmpty();
     }
 
+    @Test
+    public void testFindLocationIdsByEnvironmentId_ReturnsEmptyListWhenResultSetIsNull() {
+        int environmentId = 5;
+        String query = "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")";
+        Mockito.when(dbInteractions.query(query)).thenReturn(null);
+
+        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
+
+        List<Integer> result = repository.findLocationIdsByEnvironmentId(environmentId);
+
+        assertThat(result).isEmpty();
+    }
+
     // ---- findGridIdsByEnvironmentId ----
 
     @Test
@@ -419,6 +489,19 @@ public class EnvironmentRepositoryImplTest {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
         Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
         Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
+
+        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
+
+        List<Integer> result = repository.findGridIdsByEnvironmentId(environmentId);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testFindGridIdsByEnvironmentId_ReturnsEmptyListWhenResultSetIsNull() {
+        int environmentId = 5;
+        String query = "SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId;
+        Mockito.when(dbInteractions.query(query)).thenReturn(null);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 


### PR DESCRIPTION
## Summary
- Adds the missing `if (rs == null)` guard to the **seven** query methods of `EnvironmentRepositoryImpl` (`findAll`, `findById`, `findByName`, `findByEntityId`, `findEntityIdsByEnvironmentId`, `findLocationIdsByEnvironmentId`, `findGridIdsByEnvironmentId`), matching the existing pattern in `GridRepositoryImpl`, `EntityRepositoryImpl`, and `LocationRepositoryImpl`.
- Before this change those methods called `rs.next()` directly, so a `null` `ResultSet` — the value `DbInteractions.query(...)` returns on failure — produced a `NullPointerException` instead of an empty result, diverging from every sibling repository.
- Each guard logs with the method's existing message prefix (`"... : ResultSet is null"`) and returns the empty result (`Optional.empty()` / empty list), exactly as the siblings do.

## Tests
- Adds the seven `...ReturnsEmptyWhenResultSetIsNull` cases to `EnvironmentRepositoryImplTest`. **These are the regression guard:** without the new `rs == null` check each one throws `NullPointerException` at `rs.next()` and fails.
- Removes the now-obsolete class-level comment that documented the omission.

## Test plan
- [x] `./mvnw test -Dtest=EnvironmentRepositoryImplTest` — 45/45 pass (JDK 21)
- [x] `./mvnw test` (full suite) — 213/213 pass, no regressions
- [ ] Python client — not applicable (no `src/main/python` change)

## Notes
- The write/delegator methods (`save`, `deleteById`, `updateName`, `delete*`) are unchanged: they delegate to `DbInteractions.update`, which returns a `boolean` and has no `ResultSet` to guard.

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_