### PR TITLE
Use request-body DTOs for environment create/rename endpoints

### DIFF
--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -23,8 +23,8 @@ Deliver a working, tested API that supports:
 - [ ] `GET /api/v1/environments/{id}` – Retrieve a specific environment by ID.
 - [ ] `GET /api/v1/environments/name/{name}` – Retrieve a specific environment by name.
 - [ ] `GET /api/v1/environments/entity/{entityId}` – Get the environment containing a specific entity.
-- [ ] `POST /api/v1/environments/{name}/{numGrids}/{gridSize}` – Create an environment.
-- [ ] `PATCH /api/v1/environments/{id}/name/{name}` – Update environment name.
+- [ ] `POST /api/v1/environments` – Create an environment (JSON body: `name`, `numGrids`, `gridSize`).
+- [ ] `PATCH /api/v1/environments/{id}/name` – Update environment name (JSON body: `name`).
 - [ ] `DELETE /api/v1/environments/{id}` – Delete an environment and all related entities, locations, and grids.
 
 ---

--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -62,9 +62,9 @@ Deliver GET endpoints for all resources.
 ### **M4 – Write APIs**
 Implement creation, update, and deletion endpoints.
 
-19. **POST /environments/{name}/{numGrids}/{gridSize}** — Create environment with grids and locations.  
+19. **POST /environments** — Create environment with grids and locations (JSON body: `name`, `numGrids`, `gridSize`).  
 20. **DELETE /environments/{id}** — Delete environment with related data.  
-21. **PATCH /environments/{id}/name/{name}** — Update environment name.  
+21. **PATCH /environments/{id}/name** — Update environment name (JSON body: `name`).  
 31. **PUT /locations/{locationId}/entity/{entityId}** — Add entity to location.  
 32. **DELETE /locations/{locationId}/entity/{entityId}** — Remove entity from a specific location.  
 33. **DELETE /locations/entity/{entityId}** — Remove entity from its current location.  

--- a/src/main/java/preponderous/viron/controllers/EnvironmentController.java
+++ b/src/main/java/preponderous/viron/controllers/EnvironmentController.java
@@ -9,7 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import preponderous.viron.dto.CreateEnvironmentRequest;
 import preponderous.viron.dto.EnvironmentDto;
+import preponderous.viron.dto.UpdateEnvironmentNameRequest;
 import preponderous.viron.exceptions.NotFoundException;
 import preponderous.viron.exceptions.ServiceException;
 import preponderous.viron.factories.EnvironmentFactory;
@@ -17,6 +19,7 @@ import preponderous.viron.mappers.EnvironmentMapper;
 import preponderous.viron.models.Environment;
 import preponderous.viron.repositories.EnvironmentRepository;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
@@ -58,13 +61,11 @@ public class EnvironmentController {
         return environmentMapper.toDto(environment);
     }
 
-    @PostMapping("/{name}/{numGrids}/{gridSize}")
+    @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public EnvironmentDto createEnvironment(
-            @PathVariable @NotBlank String name,
-            @PathVariable @Min(1) int numGrids,
-            @PathVariable @Min(1) int gridSize) {
-        Environment newEnvironment = environmentFactory.createEnvironment(name, numGrids, gridSize);
+    public EnvironmentDto createEnvironment(@Valid @RequestBody CreateEnvironmentRequest request) {
+        Environment newEnvironment = environmentFactory.createEnvironment(
+                request.getName(), request.getNumGrids(), request.getGridSize());
         return environmentMapper.toDto(newEnvironment);
     }
 
@@ -138,8 +139,9 @@ public class EnvironmentController {
         log.info("Environment with id {} deleted", id);
     }
 
-    @PatchMapping("/{id}/name/{name}")
-    public void updateEnvironmentName(@PathVariable @Min(1) int id, @PathVariable @NotBlank String name) {
+    @PatchMapping("/{id}/name")
+    public void updateEnvironmentName(@PathVariable @Min(1) int id, @Valid @RequestBody UpdateEnvironmentNameRequest request) {
+        String name = request.getName();
         if (environmentRepository.findById(id).isEmpty()) {
             throw new NotFoundException("Environment not found with id: " + id);
         }

--- a/src/main/java/preponderous/viron/dto/CreateEnvironmentRequest.java
+++ b/src/main/java/preponderous/viron/dto/CreateEnvironmentRequest.java
@@ -1,0 +1,26 @@
+package preponderous.viron.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request body for creating an environment")
+public class CreateEnvironmentRequest {
+    @NotBlank
+    @Schema(description = "Name of the environment to create")
+    private String name;
+
+    @Min(1)
+    @Schema(description = "Number of grids to create in the environment")
+    private int numGrids;
+
+    @Min(1)
+    @Schema(description = "Size (rows and columns) of each grid")
+    private int gridSize;
+}

--- a/src/main/java/preponderous/viron/dto/UpdateEnvironmentNameRequest.java
+++ b/src/main/java/preponderous/viron/dto/UpdateEnvironmentNameRequest.java
@@ -1,0 +1,17 @@
+package preponderous.viron.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request body for updating an environment's name")
+public class UpdateEnvironmentNameRequest {
+    @NotBlank
+    @Schema(description = "New name for the environment")
+    private String name;
+}

--- a/src/main/java/preponderous/viron/services/EnvironmentService.java
+++ b/src/main/java/preponderous/viron/services/EnvironmentService.java
@@ -8,12 +8,15 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import preponderous.viron.config.ServiceConfig;
+import preponderous.viron.dto.CreateEnvironmentRequest;
+import preponderous.viron.dto.UpdateEnvironmentNameRequest;
 import preponderous.viron.exceptions.ServiceException;
 import preponderous.viron.models.Environment;
 
@@ -69,13 +72,10 @@ public class EnvironmentService {
     public Environment createEnvironment(String name, int numGrids, int gridSize) {
         RestTemplate restTemplate = restTemplateBuilder.build();
         ResponseEntity<Environment> response = restTemplate.exchange(
-                baseUrl + "/{name}/{numGrids}/{gridSize}",
+                baseUrl,
                 HttpMethod.POST,
-                null,
-                Environment.class,
-                name,
-                numGrids,
-                gridSize
+                new HttpEntity<>(new CreateEnvironmentRequest(name, numGrids, gridSize)),
+                Environment.class
         );
         if (response.getStatusCode().isError()) {
             throw new ServiceException("Error creating environment");
@@ -95,12 +95,11 @@ public class EnvironmentService {
     public boolean updateEnvironmentName(int id, String name) {
         RestTemplate restTemplate = restTemplateBuilder.build();
         ResponseEntity<Void> response = restTemplate.exchange(
-                baseUrl + "/{id}/name/{name}",
+                baseUrl + "/{id}/name",
                 HttpMethod.PATCH,
-                null,
+                new HttpEntity<>(new UpdateEnvironmentNameRequest(name)),
                 Void.class,
-                id,
-                name
+                id
         );
         if (response.getStatusCode().isError()) {
             throw new ServiceException("Error updating environment name");

--- a/src/main/python/preponderous/viron/services/environmentService.py
+++ b/src/main/python/preponderous/viron/services/environmentService.py
@@ -34,7 +34,8 @@ class EnvironmentService:
         return Environment(**response.json())
 
     def create_environment(self, name: str, num_grids: int, grid_size: int) -> Environment:
-        response = requests.post(f"{self.get_base_url()}/{name}/{num_grids}/{grid_size}")
+        payload = {"name": name, "numGrids": num_grids, "gridSize": grid_size}
+        response = requests.post(f"{self.get_base_url()}", json=payload)
         response.raise_for_status()
         return Environment(**response.json())
 
@@ -44,6 +45,6 @@ class EnvironmentService:
         return response.status_code == 200
 
     def update_environment_name(self, environment_id: int, name: str) -> bool:
-        response = requests.patch(f"{self.get_base_url()}/{environment_id}/name/{name}")
+        response = requests.patch(f"{self.get_base_url()}/{environment_id}/name", json={"name": name})
         response.raise_for_status()
         return response.status_code == 200

--- a/src/test/java/preponderous/viron/controllers/EnvironmentControllerTest.java
+++ b/src/test/java/preponderous/viron/controllers/EnvironmentControllerTest.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import preponderous.viron.config.DbConfig;
@@ -196,7 +197,9 @@ class EnvironmentControllerTest {
         when(environmentFactory.createEnvironment("NewEnv", 5, 10)).thenReturn(environment);
         when(environmentMapper.toDto(environment)).thenReturn(dto);
 
-        mockMvc.perform(post("/api/v1/environments/NewEnv/5/10"))
+        mockMvc.perform(post("/api/v1/environments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"NewEnv\",\"numGrids\":5,\"gridSize\":10}"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.environmentId", is(1)))
                 .andExpect(jsonPath("$.name", is("NewEnv")))
@@ -211,7 +214,9 @@ class EnvironmentControllerTest {
         when(environmentFactory.createEnvironment("NewEnv", 5, 10))
                 .thenThrow(new EnvironmentCreationException("Creation failed"));
 
-        mockMvc.perform(post("/api/v1/environments/NewEnv/5/10"))
+        mockMvc.perform(post("/api/v1/environments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"NewEnv\",\"numGrids\":5,\"gridSize\":10}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status", is(400)))
                 .andExpect(jsonPath("$.message", is("Creation failed")));
@@ -222,10 +227,34 @@ class EnvironmentControllerTest {
         when(environmentFactory.createEnvironment("NewEnv", 5, 10))
                 .thenThrow(new RuntimeException("Database error"));
 
-        mockMvc.perform(post("/api/v1/environments/NewEnv/5/10"))
+        mockMvc.perform(post("/api/v1/environments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"NewEnv\",\"numGrids\":5,\"gridSize\":10}"))
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.status", is(500)))
                 .andExpect(jsonPath("$.message", is("An unexpected error occurred")));
+    }
+
+    @Test
+    void createEnvironment_BlankName_ReturnsBadRequest() throws Exception {
+        mockMvc.perform(post("/api/v1/environments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"\",\"numGrids\":5,\"gridSize\":10}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status", is(400)));
+
+        verify(environmentFactory, never()).createEnvironment(anyString(), anyInt(), anyInt());
+    }
+
+    @Test
+    void createEnvironment_NonPositiveNumGrids_ReturnsBadRequest() throws Exception {
+        mockMvc.perform(post("/api/v1/environments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"NewEnv\",\"numGrids\":0,\"gridSize\":10}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status", is(400)));
+
+        verify(environmentFactory, never()).createEnvironment(anyString(), anyInt(), anyInt());
     }
 
     @Test
@@ -266,7 +295,9 @@ class EnvironmentControllerTest {
         when(environmentRepository.findById(1)).thenReturn(Optional.of(new Environment(1, "OldName", "2023-01-01")));
         when(environmentRepository.updateName(1, "NewName")).thenReturn(true);
 
-        mockMvc.perform(patch("/api/v1/environments/1/name/NewName"))
+        mockMvc.perform(patch("/api/v1/environments/1/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"NewName\"}"))
                 .andExpect(status().isOk());
 
         verify(environmentRepository).updateName(1, "NewName");
@@ -276,7 +307,9 @@ class EnvironmentControllerTest {
     void updateEnvironmentName_NotFound() throws Exception {
         when(environmentRepository.findById(1)).thenReturn(Optional.empty());
 
-        mockMvc.perform(patch("/api/v1/environments/1/name/NewName"))
+        mockMvc.perform(patch("/api/v1/environments/1/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"NewName\"}"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status", is(404)))
                 .andExpect(jsonPath("$.message", is("Environment not found with id: 1")));
@@ -289,9 +322,22 @@ class EnvironmentControllerTest {
         when(environmentRepository.findById(1)).thenReturn(Optional.of(new Environment(1, "OldName", "2023-01-01")));
         when(environmentRepository.updateName(1, "NewName")).thenThrow(new RuntimeException("Database error"));
 
-        mockMvc.perform(patch("/api/v1/environments/1/name/NewName"))
+        mockMvc.perform(patch("/api/v1/environments/1/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"NewName\"}"))
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.status", is(500)))
                 .andExpect(jsonPath("$.message", is("An unexpected error occurred")));
+    }
+
+    @Test
+    void updateEnvironmentName_BlankName_ReturnsBadRequest() throws Exception {
+        mockMvc.perform(patch("/api/v1/environments/1/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status", is(400)));
+
+        verify(environmentRepository, never()).updateName(anyInt(), anyString());
     }
 }

--- a/src/test/python/preponderous/viron/services/test_environmentService.py
+++ b/src/test/python/preponderous/viron/services/test_environmentService.py
@@ -102,7 +102,10 @@ def test_create_environment(mock_post):
 
     assert isinstance(environment, Environment)
     assert environment.getName() == 'TestEnv'
-    mock_post.assert_called_once_with("http://localhost:9999/api/v1/environments/TestEnv/10/10")
+    mock_post.assert_called_once_with(
+        "http://localhost:9999/api/v1/environments",
+        json={"name": "TestEnv", "numGrids": 10, "gridSize": 10},
+    )
 
 @patch('requests.delete')
 def test_delete_environment(mock_delete):
@@ -126,7 +129,10 @@ def test_update_environment_name(mock_patch):
     result = service.update_environment_name(1, 'NewName')
 
     assert result is True
-    mock_patch.assert_called_once_with("http://localhost:9999/api/v1/environments/1/name/NewName")
+    mock_patch.assert_called_once_with(
+        "http://localhost:9999/api/v1/environments/1/name",
+        json={"name": "NewName"},
+    )
 
 @patch('requests.get')
 def test_get_all_environments_empty(mock_get):


### PR DESCRIPTION
## Summary
Aligns the two **environment** write endpoints with the OpenAPI contract, which already specifies request bodies and the `CreateEnvironmentRequest` / `UpdateEnvironmentNameRequest` schemas that were never implemented (the gap #128 calls out):

| Endpoint | Before | After |
|---|---|---|
| Create | `POST /api/v1/environments/{name}/{numGrids}/{gridSize}` | `POST /api/v1/environments` + `CreateEnvironmentRequest` body `{name, numGrids, gridSize}` |
| Rename | `PATCH /api/v1/environments/{id}/name/{name}` | `PATCH /api/v1/environments/{id}/name` + `UpdateEnvironmentNameRequest` body `{name}` |

- New DTOs carry the same validation the path variables enforced (`@NotBlank` name, `@Min(1)` numGrids/gridSize) via `@Valid @RequestBody`; invalid input returns **400** through the existing `GlobalExceptionHandler`.
- Keeps **all three representations** in lockstep:
  - **Server** controller (`EnvironmentController`).
  - **Java client SDK** (`services/EnvironmentService`, consumed by `DebugController`) — now sends `HttpEntity` bodies to the new paths instead of the old path-variable URLs (would otherwise 404).
  - **Python client** (`services/environmentService`).
- Updates the **MockMvc tests** (rewrote the 6 create/rename tests for JSON bodies; added 3 validation tests: blank name, non-positive numGrids, blank rename) and the **Python client tests**.
- Updates the drifted **`docs/MVP.md` / `docs/PLANNING.md`** endpoint descriptions, which still documented the path-variable forms.
- **No change to `docs/openapi/viron-api.json`** — the spec was already correct; the code is now aligned to it.

## Scope / split
This resolves the **environment** half of #128. The **entity** write endpoints are the same anti-pattern but are **not defined in the OpenAPI spec at all**, so aligning them additionally requires authoring the entity resource in `viron-api.json` (a wire-contract change needing human review). That work is split into **#135** to keep this PR coherent and auto-mergeable. Pre-existing wholesale Postman collection drift is split into **#136**.

Partially addresses #128 (environment endpoints); does not auto-close it — see #135 for the remaining entity portion.

## Known out-of-scope discrepancy
The spec says `POST /api/v1/environments` returns **200**, but the controller returns **201 Created** (more correct for a creation). This PR is input-shape-only and leaves the status as-is; tracked in #135 for a spec-accuracy pass.

## ⚠️ Breaking change
The two endpoints' URLs change. Acceptable pre-MVP; the spec was always the intended contract (confirmed with the maintainer).

## Test plan
- [x] `./mvnw test` (full suite) — **216/216 pass** (was 213; +3 validation tests), JDK 21
- [x] `pytest src/test/python` — **80/80 pass** (Python 3.11). CI does **not** run Python, so this local run is the Python anchor.
- [x] Endpoints verified against `docs/openapi/viron-api.json` (path, verb, body schema match exactly)
- [x] Java client SDK + Python client both updated to the new contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_