### PR TITLE
Guard EntityFactory against null ResultSet and -1 id sentinel

### DIFF
--- a/src/main/java/preponderous/viron/factories/EntityFactory.java
+++ b/src/main/java/preponderous/viron/factories/EntityFactory.java
@@ -26,6 +26,10 @@ public class EntityFactory {
     public Entity createEntity(String name) throws EntityCreationException {
         log.info("Attempting to create entity with name: {}", name);
         int id = getNextEntityId();
+        if (id == -1) {
+            log.error("Failed to get next entity id");
+            throw new EntityCreationException("Failed to get next entity id");
+        }
         String creationDate = new java.util.Date().toString();
         String query = "INSERT INTO viron.entity (entity_id, name, creation_date) VALUES (" + id + ", '" + name + "', '" + creationDate + "')";
         boolean success = dbInteractions.update(query);
@@ -38,6 +42,9 @@ public class EntityFactory {
 
     private int getNextEntityId() {
         ResultSet rs = dbInteractions.query("SELECT nextval('viron.entity_id_seq')");
+        if (rs == null) {
+            return -1;
+        }
         try {
             if (rs.next()) {
                 return rs.getInt(1);

--- a/src/test/java/preponderous/viron/factories/EntityFactoryTest.java
+++ b/src/test/java/preponderous/viron/factories/EntityFactoryTest.java
@@ -1,0 +1,87 @@
+package preponderous.viron.factories;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import preponderous.viron.database.DbInteractions;
+import preponderous.viron.exceptions.EntityCreationException;
+import preponderous.viron.models.Entity;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+public class EntityFactoryTest {
+
+    private static final String NEXT_ID_QUERY = "SELECT nextval('viron.entity_id_seq')";
+
+    @MockBean
+    private DbInteractions dbInteractions;
+
+    @Test
+    public void testCreateEntity_Success_ReturnsEntity() throws SQLException {
+        ResultSet idRs = Mockito.mock(ResultSet.class);
+        Mockito.when(dbInteractions.query(NEXT_ID_QUERY)).thenReturn(idRs);
+        Mockito.when(idRs.next()).thenReturn(true);
+        Mockito.when(idRs.getInt(1)).thenReturn(5);
+        Mockito.when(dbInteractions.update(anyString())).thenReturn(true);
+
+        EntityFactory factory = new EntityFactory(dbInteractions);
+
+        Entity result = factory.createEntity("Bob");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getEntityId()).isEqualTo(5);
+        assertThat(result.getName()).isEqualTo("Bob");
+    }
+
+    // #138 case 1: a null ResultSet from a failed nextval query must not NPE.
+    @Test
+    public void testCreateEntity_NullResultSet_ThrowsAndDoesNotInsert() {
+        Mockito.when(dbInteractions.query(NEXT_ID_QUERY)).thenReturn(null);
+
+        EntityFactory factory = new EntityFactory(dbInteractions);
+
+        assertThatThrownBy(() -> factory.createEntity("Bob"))
+                .isInstanceOf(EntityCreationException.class)
+                .hasMessage("Failed to get next entity id");
+        verify(dbInteractions, never()).update(anyString());
+    }
+
+    // #138 case 2: a -1 sentinel id must not be inserted.
+    @Test
+    public void testCreateEntity_NextIdUnavailable_ThrowsAndDoesNotInsert() throws SQLException {
+        ResultSet idRs = Mockito.mock(ResultSet.class);
+        Mockito.when(dbInteractions.query(NEXT_ID_QUERY)).thenReturn(idRs);
+        Mockito.when(idRs.next()).thenReturn(false); // no row -> getNextEntityId() returns -1
+
+        EntityFactory factory = new EntityFactory(dbInteractions);
+
+        assertThatThrownBy(() -> factory.createEntity("Bob"))
+                .isInstanceOf(EntityCreationException.class)
+                .hasMessage("Failed to get next entity id");
+        verify(dbInteractions, never()).update(anyString());
+    }
+
+    @Test
+    public void testCreateEntity_InsertFails_Throws() throws SQLException {
+        ResultSet idRs = Mockito.mock(ResultSet.class);
+        Mockito.when(dbInteractions.query(NEXT_ID_QUERY)).thenReturn(idRs);
+        Mockito.when(idRs.next()).thenReturn(true);
+        Mockito.when(idRs.getInt(1)).thenReturn(5);
+        Mockito.when(dbInteractions.update(anyString())).thenReturn(false);
+
+        EntityFactory factory = new EntityFactory(dbInteractions);
+
+        assertThatThrownBy(() -> factory.createEntity("Bob"))
+                .isInstanceOf(EntityCreationException.class)
+                .hasMessageContaining("Error creating entity with name: Bob");
+    }
+}


### PR DESCRIPTION
## Summary
`EntityFactory` implemented the same "get next id from a sequence, then INSERT" pattern as `EnvironmentFactory` but omitted two safety checks the latter performs, leaving two defects on the live entity-creation path (`POST /api/v1/entities/{name}` and `DebugController`):

1. **Unguarded null `ResultSet` → NPE.** `getNextEntityId()` called `rs.next()` without checking `rs`. `DbInteractions.query(...)` returns `null` on failure, so a failed/locked query threw `NullPointerException` instead of returning `-1`. Fixed with `if (rs == null) return -1;` (matches `EnvironmentFactory`).
2. **Unchecked `-1` sentinel → bad INSERT.** `createEntity()` never checked `id == -1` before building the INSERT, so on failure it would write a row with `entity_id = -1`. Fixed with an `if (id == -1)` guard that logs and throws `EntityCreationException` (matches `EnvironmentFactory`).

## Tests
Adds `EntityFactoryTest` (mocks `DbInteractions`, mirroring the repository tests' `@SpringBootTest` + `@MockBean` style):
- success path returns the entity;
- null-ResultSet → throws, and **asserts no `update`/INSERT is attempted**;
- nextval returns no row (`-1`) → throws, and **asserts no `update`/INSERT is attempted**;
- INSERT failure → throws.

Both guard tests were confirmed to **fail without the fix** (NPE on the null case; the `-1` case attempts the INSERT and trips the `never().update(...)` verification).

## Test plan
- [x] `./mvnw test` — **220/220 pass** (was 216; +4), JDK 21
- [x] Regression demonstrated: reverting `EntityFactory.java` to `main` makes the two guard tests fail
- [ ] Python client — n/a (no `src/main/python` change)

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_