### PR TITLE
Parameterize SQL and close JDBC resources in DbInteractions (#139, #140)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- In-memory database used only to exercise DbInteractions (parameter binding + resource handling) in tests. -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>

--- a/src/main/java/preponderous/viron/database/DbInteractions.java
+++ b/src/main/java/preponderous/viron/database/DbInteractions.java
@@ -5,8 +5,12 @@ package preponderous.viron.database;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import javax.sql.rowset.CachedRowSet;
+import javax.sql.rowset.RowSetProvider;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,23 +33,57 @@ public class DbInteractions {
         this.connection = connect();
     }
 
-    public ResultSet query(String query) {
-        try {
-            return connection.createStatement().executeQuery(query);
+    /**
+     * Execute a parameterized SELECT and return a disconnected result.
+     *
+     * <p>The query is run through a {@link PreparedStatement} so caller-supplied
+     * values are bound as parameters rather than concatenated into SQL. The
+     * statement and live result set are closed before returning; the rows are
+     * copied into a {@link CachedRowSet} so callers can read them without leaking
+     * JDBC resources.
+     *
+     * @param query  SQL with {@code ?} placeholders for each parameter
+     * @param params values to bind to the placeholders, in order
+     * @return a disconnected {@link ResultSet} of the rows, or {@code null} on error
+     */
+    public ResultSet query(String query, Object... params) {
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            bindParameters(statement, params);
+            try (ResultSet rs = statement.executeQuery()) {
+                CachedRowSet cachedRowSet = RowSetProvider.newFactory().createCachedRowSet();
+                cachedRowSet.populate(rs);
+                return cachedRowSet;
+            }
         } catch (SQLException e) {
             log.error("Error executing query: {}", e.getMessage());
         }
         return null;
     }
 
-    public boolean update(String query) {
-        try {
-            int rowCount = connection.createStatement().executeUpdate(query);
-            return rowCount > 0;
+    /**
+     * Execute a parameterized INSERT/UPDATE/DELETE.
+     *
+     * <p>Run through a {@link PreparedStatement} (parameters bound, not concatenated)
+     * inside a try-with-resources so the statement is always closed.
+     *
+     * @param query  SQL with {@code ?} placeholders for each parameter
+     * @param params values to bind to the placeholders, in order
+     * @return {@code true} if at least one row was affected, {@code false} otherwise (including on error)
+     */
+    public boolean update(String query, Object... params) {
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            bindParameters(statement, params);
+            return statement.executeUpdate() > 0;
         } catch (SQLException e) {
             log.error("Error executing update: {}", e.getMessage());
         }
         return false;
+    }
+
+    private void bindParameters(PreparedStatement statement, Object... params) throws SQLException {
+        for (int i = 0; i < params.length; i++) {
+            statement.setObject(i + 1, params[i]);
+        }
     }
 
     public void close() {

--- a/src/main/java/preponderous/viron/factories/EntityFactory.java
+++ b/src/main/java/preponderous/viron/factories/EntityFactory.java
@@ -31,8 +31,8 @@ public class EntityFactory {
             throw new EntityCreationException("Failed to get next entity id");
         }
         String creationDate = new java.util.Date().toString();
-        String query = "INSERT INTO viron.entity (entity_id, name, creation_date) VALUES (" + id + ", '" + name + "', '" + creationDate + "')";
-        boolean success = dbInteractions.update(query);
+        String query = "INSERT INTO viron.entity (entity_id, name, creation_date) VALUES (" + id + ", ?, ?)";
+        boolean success = dbInteractions.update(query, name, creationDate);
         if (success) {
             log.info("Successfully created entity with name: {} and id: {} and creation date: {}", name, id, creationDate);
             return new Entity(id, name, creationDate);

--- a/src/main/java/preponderous/viron/factories/EnvironmentFactory.java
+++ b/src/main/java/preponderous/viron/factories/EnvironmentFactory.java
@@ -35,8 +35,8 @@ public class EnvironmentFactory {
             throw new EnvironmentCreationException("Failed to get next environment id");
         }
         String creationDate = new java.util.Date().toString();
-        String query = "INSERT INTO viron.environment (environment_id, name, creation_date) VALUES (" + id + ", '" + name + "', '" + creationDate + "')";
-        boolean success = dbInteractions.update(query);
+        String query = "INSERT INTO viron.environment (environment_id, name, creation_date) VALUES (" + id + ", ?, ?)";
+        boolean success = dbInteractions.update(query, name, creationDate);
         if (!success) {
             log.error("Failed to create environment");
             throw new EnvironmentCreationException("Failed to create environment");

--- a/src/main/java/preponderous/viron/repositories/EntityRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/EntityRepositoryImpl.java
@@ -152,9 +152,8 @@ public class EntityRepositoryImpl implements EntityRepository {
     @Override
     public Entity save(Entity entity) {
         if (entity.getEntityId() == 0) {
-            String query = String.format("INSERT INTO viron.entity (name, creation_date) VALUES ('%s', NOW())",
-                    entity.getName());
-            if (dbInteractions.update(query)) {
+            String query = "INSERT INTO viron.entity (name, creation_date) VALUES (?, NOW())";
+            if (dbInteractions.update(query, entity.getName())) {
                 // Get the last inserted id
                 ResultSet rs = dbInteractions.query("SELECT LAST_INSERT_ID()");
                 try {
@@ -177,8 +176,7 @@ public class EntityRepositoryImpl implements EntityRepository {
 
     @Override
     public boolean updateName(int id, String name) {
-        String query = String.format("UPDATE viron.entity SET name = '%s' WHERE entity_id = %d",
-                name, id);
-        return dbInteractions.update(query);
+        String query = "UPDATE viron.entity SET name = ? WHERE entity_id = " + id;
+        return dbInteractions.update(query, name);
     }
 }

--- a/src/main/java/preponderous/viron/repositories/EnvironmentRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/EnvironmentRepositoryImpl.java
@@ -59,7 +59,7 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
 
     @Override
     public Optional<Environment> findByName(String name) {
-        ResultSet rs = dbInteractions.query("SELECT * FROM viron.environment WHERE name = '" + name + "'");
+        ResultSet rs = dbInteractions.query("SELECT * FROM viron.environment WHERE name = ?", name);
         if (rs == null) {
             log.error("Error finding environment by name: ResultSet is null");
             return Optional.empty();
@@ -104,8 +104,8 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
 
     @Override
     public boolean updateName(int id, String name) {
-        String query = "UPDATE viron.environment SET name = '" + name + "' WHERE environment_id = " + id;
-        return dbInteractions.update(query);
+        String query = "UPDATE viron.environment SET name = ? WHERE environment_id = " + id;
+        return dbInteractions.update(query, name);
     }
 
     @Override

--- a/src/test/java/preponderous/viron/database/DbInteractionsTest.java
+++ b/src/test/java/preponderous/viron/database/DbInteractionsTest.java
@@ -1,0 +1,93 @@
+package preponderous.viron.database;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import preponderous.viron.config.DbConfig;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises {@link DbInteractions} against an in-memory H2 database to verify
+ * parameter binding (#139) and resource handling (#140). The application's real
+ * SQL is Postgres-specific; this test uses its own neutral schema and only
+ * validates the generic query/update mechanism.
+ */
+public class DbInteractionsTest {
+
+    private DbInteractions dbInteractions;
+
+    @BeforeEach
+    void setUp() {
+        DbConfig config = new DbConfig();
+        config.setDbUrl("jdbc:h2:mem:viron_dbinteractions;DB_CLOSE_DELAY=-1");
+        config.setDbUsername("sa");
+        config.setDbPassword("");
+        dbInteractions = new DbInteractions(config);
+
+        dbInteractions.update("DROP TABLE IF EXISTS person");
+        dbInteractions.update("CREATE TABLE person (id INT PRIMARY KEY, name VARCHAR(255))");
+    }
+
+    @Test
+    void update_bindsParameters_andQueryReturnsMatchingRow() throws SQLException {
+        boolean inserted = dbInteractions.update("INSERT INTO person (id, name) VALUES (?, ?)", 1, "Alice");
+        assertThat(inserted).isTrue();
+
+        ResultSet rs = dbInteractions.query("SELECT id, name FROM person WHERE id = ?", 1);
+
+        assertThat(rs).isNotNull();
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getInt("id")).isEqualTo(1);
+        assertThat(rs.getString("name")).isEqualTo("Alice");
+        assertThat(rs.next()).isFalse();
+    }
+
+    // #139: a value containing a quote / SQL payload must be stored verbatim, never executed.
+    @Test
+    void parameterizedValueWithSqlPayload_isStoredLiterally_andDoesNotInject() throws SQLException {
+        String tricky = "O'Brien'); DROP TABLE person; --";
+
+        assertThat(dbInteractions.update("INSERT INTO person (id, name) VALUES (?, ?)", 2, tricky)).isTrue();
+
+        // The table still exists (payload did not execute) and the value round-trips intact.
+        ResultSet rs = dbInteractions.query("SELECT name FROM person WHERE id = ?", 2);
+        assertThat(rs).isNotNull();
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("name")).isEqualTo(tricky);
+    }
+
+    // #140: query() returns a disconnected result that stays readable after the method has
+    // returned and closed its PreparedStatement and live ResultSet internally.
+    @Test
+    void query_returnsDisconnectedResultSet_readableAfterReturn() throws SQLException {
+        dbInteractions.update("INSERT INTO person (id, name) VALUES (?, ?)", 3, "Carol");
+        dbInteractions.update("INSERT INTO person (id, name) VALUES (?, ?)", 4, "Dave");
+
+        ResultSet rs = dbInteractions.query("SELECT id, name FROM person ORDER BY id");
+
+        assertThat(rs).isNotNull();
+        int count = 0;
+        while (rs.next()) {
+            count++;
+        }
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void query_onInvalidSql_returnsNullAndDoesNotThrow() {
+        assertThat(dbInteractions.query("SELECT * FROM does_not_exist")).isNull();
+    }
+
+    @Test
+    void update_onInvalidSql_returnsFalseAndDoesNotThrow() {
+        assertThat(dbInteractions.update("UPDATE does_not_exist SET name = ?", "x")).isFalse();
+    }
+
+    @Test
+    void update_affectingNoRows_returnsFalse() {
+        assertThat(dbInteractions.update("UPDATE person SET name = ? WHERE id = ?", "Nobody", 999)).isFalse();
+    }
+}

--- a/src/test/java/preponderous/viron/factories/EntityFactoryTest.java
+++ b/src/test/java/preponderous/viron/factories/EntityFactoryTest.java
@@ -13,6 +13,7 @@ import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -31,7 +32,7 @@ public class EntityFactoryTest {
         Mockito.when(dbInteractions.query(NEXT_ID_QUERY)).thenReturn(idRs);
         Mockito.when(idRs.next()).thenReturn(true);
         Mockito.when(idRs.getInt(1)).thenReturn(5);
-        Mockito.when(dbInteractions.update(anyString())).thenReturn(true);
+        Mockito.when(dbInteractions.update(anyString(), any(), any())).thenReturn(true);
 
         EntityFactory factory = new EntityFactory(dbInteractions);
 
@@ -76,7 +77,7 @@ public class EntityFactoryTest {
         Mockito.when(dbInteractions.query(NEXT_ID_QUERY)).thenReturn(idRs);
         Mockito.when(idRs.next()).thenReturn(true);
         Mockito.when(idRs.getInt(1)).thenReturn(5);
-        Mockito.when(dbInteractions.update(anyString())).thenReturn(false);
+        Mockito.when(dbInteractions.update(anyString(), any(), any())).thenReturn(false);
 
         EntityFactory factory = new EntityFactory(dbInteractions);
 

--- a/src/test/java/preponderous/viron/repositories/EntityRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/EntityRepositoryImplTest.java
@@ -514,7 +514,7 @@ public class EntityRepositoryImplTest {
         Entity entityToSave = new Entity(0, "Entity1", null);
 
         // Mock the insert operation
-        Mockito.when(dbInteractions.update("INSERT INTO viron.entity (name, creation_date) VALUES ('Entity1', NOW())"))
+        Mockito.when(dbInteractions.update("INSERT INTO viron.entity (name, creation_date) VALUES (?, NOW())", "Entity1"))
                 .thenReturn(true);
 
         // Mock getting the last inserted ID
@@ -549,7 +549,7 @@ public class EntityRepositoryImplTest {
         // Arrange
         Entity entityToSave = new Entity(0, "Entity1", null); // ID is 0 for new entity
 
-        Mockito.when(dbInteractions.update("INSERT INTO viron.entity (name, creation_date) VALUES ('Entity1', NOW())"))
+        Mockito.when(dbInteractions.update("INSERT INTO viron.entity (name, creation_date) VALUES (?, NOW())", "Entity1"))
                 .thenReturn(false);
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -566,7 +566,7 @@ public class EntityRepositoryImplTest {
         // Arrange
         Entity entityToSave = new Entity(0, "Entity1", null); // ID is 0 for new entity
 
-        Mockito.when(dbInteractions.update("INSERT INTO viron.entity (name, creation_date) VALUES ('Entity1', NOW())"))
+        Mockito.when(dbInteractions.update("INSERT INTO viron.entity (name, creation_date) VALUES (?, NOW())", "Entity1"))
                 .thenReturn(false); // Instead of throwing SQLException, just return false
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -631,7 +631,7 @@ public class EntityRepositoryImplTest {
         // Arrange
         int entityId = 1;
         String newName = "UpdatedEntityName";
-        Mockito.when(dbInteractions.update("UPDATE viron.entity SET name = 'UpdatedEntityName' WHERE entity_id = 1"))
+        Mockito.when(dbInteractions.update("UPDATE viron.entity SET name = ? WHERE entity_id = 1", "UpdatedEntityName"))
                 .thenReturn(true);
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -648,7 +648,7 @@ public class EntityRepositoryImplTest {
         // Arrange
         int entityId = 1;
         String newName = "UpdatedEntityName";
-        Mockito.when(dbInteractions.update("UPDATE viron.entity SET name = 'UpdatedEntityName' WHERE entity_id = 1"))
+        Mockito.when(dbInteractions.update("UPDATE viron.entity SET name = ? WHERE entity_id = 1", "UpdatedEntityName"))
                 .thenReturn(false);
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -665,7 +665,7 @@ public class EntityRepositoryImplTest {
         // Arrange
         int entityId = 1;
         String newName = "UpdatedEntityName";
-        Mockito.when(dbInteractions.update("UPDATE viron.entity SET name = 'UpdatedEntityName' WHERE entity_id = 1"))
+        Mockito.when(dbInteractions.update("UPDATE viron.entity SET name = ? WHERE entity_id = 1", "UpdatedEntityName"))
                 .thenReturn(false); // Instead of throwing SQLException, just return false
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);

--- a/src/test/java/preponderous/viron/repositories/EnvironmentRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/EnvironmentRepositoryImplTest.java
@@ -149,7 +149,7 @@ public class EnvironmentRepositoryImplTest {
     public void testFindByName_ReturnsEnvironmentWhenRowExists() throws SQLException {
         String name = "Env1";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE name = '" + name + "'")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE name = ?", name)).thenReturn(mockResultSet);
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("environment_id")).thenReturn(1);
         Mockito.when(mockResultSet.getString("name")).thenReturn(name);
@@ -169,7 +169,7 @@ public class EnvironmentRepositoryImplTest {
     public void testFindByName_ReturnsEmptyWhenNoRow() throws SQLException {
         String name = "Env1";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE name = '" + name + "'")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE name = ?", name)).thenReturn(mockResultSet);
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -183,7 +183,7 @@ public class EnvironmentRepositoryImplTest {
     public void testFindByName_ReturnsEmptyWhenSQLExceptionThrown() throws SQLException {
         String name = "Env1";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE name = '" + name + "'")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE name = ?", name)).thenReturn(mockResultSet);
         Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -196,7 +196,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindByName_ReturnsEmptyWhenResultSetIsNull() {
         String name = "Env1";
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE name = '" + name + "'")).thenReturn(null);
+        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE name = ?", name)).thenReturn(null);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -309,7 +309,7 @@ public class EnvironmentRepositoryImplTest {
     public void testUpdateName_ReturnsTrueWhenUpdateSucceeds() {
         int id = 1;
         String name = "NewName";
-        Mockito.when(dbInteractions.update("UPDATE viron.environment SET name = '" + name + "' WHERE environment_id = " + id)).thenReturn(true);
+        Mockito.when(dbInteractions.update("UPDATE viron.environment SET name = ? WHERE environment_id = " + id, name)).thenReturn(true);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -320,7 +320,7 @@ public class EnvironmentRepositoryImplTest {
     public void testUpdateName_ReturnsFalseWhenUpdateFails() {
         int id = 1;
         String name = "NewName";
-        Mockito.when(dbInteractions.update("UPDATE viron.environment SET name = '" + name + "' WHERE environment_id = " + id)).thenReturn(false);
+        Mockito.when(dbInteractions.update("UPDATE viron.environment SET name = ? WHERE environment_id = " + id, name)).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 


### PR DESCRIPTION
## Summary
Hardens the hand-rolled data layer to fix the injection/breakage risk (#139) and the JDBC resource leak (#140) together, since both live in `DbInteractions`.

**`DbInteractions` rework:**
- `query(sql, params...)` — binds parameters via `PreparedStatement`, runs inside try-with-resources, and returns a **disconnected `CachedRowSet`** (rows copied out) so the `PreparedStatement` and live `ResultSet` are always closed. Callers keep using the `ResultSet` API unchanged. Fixes the leak in #140.
- `update(sql, params...)` — binds parameters, closes the statement via try-with-resources. Fixes the leak in #140.
- Both are **varargs**, so the ~40 existing parameterless call sites compile and behave unchanged.

**Parameterization (#139):** the user-controlled `name` interpolations were moved off string concatenation to bound parameters:
- `EntityFactory` / `EnvironmentFactory` inserts
- `EntityRepositoryImpl.save` + `updateName`
- `EnvironmentRepositoryImpl.findByName` + `updateName`

Integer ids are left inline (not an injection vector); the grid/location inserts in `EnvironmentFactory` are int-only and untouched. The affected repository test mocks were updated to the parameterized call signatures.

## Tests
Adds `DbInteractionsTest` (**H2 in-memory, test scope**) — this is what actually exercises the new binding/resource behavior, since `DbInteractions` is mocked everywhere else:
- parameters bind and the row round-trips;
- **a value containing a SQL payload (`O'Brien'); DROP TABLE person; --`) is stored literally and does not inject** (the table survives) — the core #139 proof;
- the returned `ResultSet` is disconnected and fully readable after `query()` returns (evidence for the #140 resource fix);
- invalid SQL returns `null`/`false` without throwing; a no-row update returns `false`.

## ⚠️ Needs human review — not auto-merged
This PR modifies **`pom.xml`** (adds the `com.h2database:h2` test-scope dependency), which is on the do-not-auto-merge list. Flagging for manual review rather than merging automatically. The `query()` redesign (returning a `CachedRowSet` instead of a live `ResultSet`) is also a deliberate behavioral change in the core data layer worth a careful look.

## Test plan
- [x] `./mvnw test` — **226/226 pass** (was 220; +6 `DbInteractionsTest`), JDK 21
- [x] `DbInteractionsTest` runs real SQL on H2, including the injection-payload case
- [ ] Python client — n/a (no `src/main/python` change)

## Follow-up note
The deeper fix for `query()` returning a `ResultSet` at all (a `RowMapper`-style API returning `List<T>`) would let every repository drop its manual `ResultSet` handling, but that is a much larger refactor; the `CachedRowSet` approach here fixes the leak with minimal blast radius.

Closes #139
Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_