### PR TITLE
docs: reconcile MVP.md checklist with the implemented MVP

### DIFF
--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -4,6 +4,8 @@ The **Minimum Viable Product (MVP)** for Viron establishes the core spatial simu
 
 This document aligns with the [`../openapi/viron-api.json`](../openapi/viron-api.json) specification and serves as the implementation guide.
 
+> **Status:** The endpoints and DTOs below are implemented and tested; the checked boxes reflect the current implementation. The remaining gap is aligning entity creation to a request-body contract, tracked in [#135](https://github.com/Preponderous-Software/viron/issues/135).
+
 ---
 
 ## 🎯 Purpose
@@ -19,58 +21,58 @@ Deliver a working, tested API that supports:
 ## 📌 Core Features
 
 ### 1. **Environment Management**
-- [ ] `GET /api/v1/environments` – Retrieve all environments.
-- [ ] `GET /api/v1/environments/{id}` – Retrieve a specific environment by ID.
-- [ ] `GET /api/v1/environments/name/{name}` – Retrieve a specific environment by name.
-- [ ] `GET /api/v1/environments/entity/{entityId}` – Get the environment containing a specific entity.
-- [ ] `POST /api/v1/environments` – Create an environment (JSON body: `name`, `numGrids`, `gridSize`).
-- [ ] `PATCH /api/v1/environments/{id}/name` – Update environment name (JSON body: `name`).
-- [ ] `DELETE /api/v1/environments/{id}` – Delete an environment and all related entities, locations, and grids.
+- [x] `GET /api/v1/environments` – Retrieve all environments.
+- [x] `GET /api/v1/environments/{id}` – Retrieve a specific environment by ID.
+- [x] `GET /api/v1/environments/name/{name}` – Retrieve a specific environment by name.
+- [x] `GET /api/v1/environments/entity/{entityId}` – Get the environment containing a specific entity.
+- [x] `POST /api/v1/environments` – Create an environment (JSON body: `name`, `numGrids`, `gridSize`).
+- [x] `PATCH /api/v1/environments/{id}/name` – Update environment name (JSON body: `name`).
+- [x] `DELETE /api/v1/environments/{id}` – Delete an environment and all related entities, locations, and grids.
 
 ---
 
 ### 2. **Grid Management**
-- [ ] `GET /api/v1/grids` – Retrieve all grids.
-- [ ] `GET /api/v1/grids/{id}` – Retrieve a grid by ID.
-- [ ] `GET /api/v1/grids/environment/{environmentId}` – Retrieve all grids in an environment.
-- [ ] `GET /api/v1/grids/entity/{entityId}` – Retrieve the grid containing a specific entity.
+- [x] `GET /api/v1/grids` – Retrieve all grids.
+- [x] `GET /api/v1/grids/{id}` – Retrieve a grid by ID.
+- [x] `GET /api/v1/grids/environment/{environmentId}` – Retrieve all grids in an environment.
+- [x] `GET /api/v1/grids/entity/{entityId}` – Retrieve the grid containing a specific entity.
 
 ---
 
 ### 3. **Location Management**
-- [ ] `GET /api/v1/locations` – Retrieve all locations.
-- [ ] `GET /api/v1/locations/{id}` – Retrieve a location by ID.
-- [ ] `GET /api/v1/locations/environment/{environmentId}` – Retrieve locations in an environment.
-- [ ] `GET /api/v1/locations/grid/{gridId}` – Retrieve locations in a grid.
-- [ ] `GET /api/v1/locations/entity/{entityId}` – Retrieve the location of a specific entity.
-- [ ] `PUT /api/v1/locations/{locationId}/entity/{entityId}` – Add an entity to a location.
-- [ ] `DELETE /api/v1/locations/{locationId}/entity/{entityId}` – Remove an entity from a specific location.
-- [ ] `DELETE /api/v1/locations/entity/{entityId}` – Remove an entity from its current location.
+- [x] `GET /api/v1/locations` – Retrieve all locations.
+- [x] `GET /api/v1/locations/{id}` – Retrieve a location by ID.
+- [x] `GET /api/v1/locations/environment/{environmentId}` – Retrieve locations in an environment.
+- [x] `GET /api/v1/locations/grid/{gridId}` – Retrieve locations in a grid.
+- [x] `GET /api/v1/locations/entity/{entityId}` – Retrieve the location of a specific entity.
+- [x] `PUT /api/v1/locations/{locationId}/entity/{entityId}` – Add an entity to a location.
+- [x] `DELETE /api/v1/locations/{locationId}/entity/{entityId}` – Remove an entity from a specific location.
+- [x] `DELETE /api/v1/locations/entity/{entityId}` – Remove an entity from its current location.
 
 ---
 
 ### 4. **Entity Management**
-- [ ] `GET /api/v1/entities` – Retrieve all entities.
-- [ ] `GET /api/v1/entities/{id}` – Retrieve a specific entity by ID.
-- [ ] `POST /api/v1/entities` – Create a new entity.
-- [ ] `DELETE /api/v1/entities/{id}` – Delete an entity.
+- [x] `GET /api/v1/entities` – Retrieve all entities.
+- [x] `GET /api/v1/entities/{id}` – Retrieve a specific entity by ID.
+- [ ] `POST /api/v1/entities` – Create a new entity. _(Currently implemented as `POST /api/v1/entities/{name}` using a path variable; alignment to the request-body form documented here is tracked in [#135](https://github.com/Preponderous-Software/viron/issues/135).)_
+- [x] `DELETE /api/v1/entities/{id}` – Delete an entity.
 
 ---
 
 ### 5. **Debug Utilities**
-- [ ] `POST /api/v1/debug/create-sample-data` – Create an environment with grids, locations, and sample entities for testing.
-- [ ] `POST /api/v1/debug/create-world-and-place-entity/{environmentName}` – Create a world and place a random entity.
+- [x] `POST /api/v1/debug/create-sample-data` – Create an environment with grids, locations, and sample entities for testing.
+- [x] `POST /api/v1/debug/create-world-and-place-entity/{environmentName}` – Create a world and place a random entity.
 
 ---
 
 ## 🧩 DTO Requirements
 
-- [ ] **EnvironmentDTO** – Public representation of an environment.
-- [ ] **CreateEnvironmentRequest** – Request body for creating environments (name, number of grids, grid size).
-- [ ] **UpdateEnvironmentNameRequest** – Request body for updating environment names.
-- [ ] **GridDTO** – Public representation of a grid.
-- [ ] **LocationDTO** – Public representation of a location.
-- [ ] **EntityDTO** – Public representation of an entity.
+- [x] **EnvironmentDTO** – Public representation of an environment.
+- [x] **CreateEnvironmentRequest** – Request body for creating environments (name, number of grids, grid size).
+- [x] **UpdateEnvironmentNameRequest** – Request body for updating environment names.
+- [x] **GridDTO** – Public representation of a grid.
+- [x] **LocationDTO** – Public representation of a location.
+- [x] **EntityDTO** – Public representation of an entity.
 
 ---
 


### PR DESCRIPTION
## Summary
Every item in `docs/MVP.md`'s checklist was unchecked (`- [ ]`) even though the endpoints and DTOs are implemented and tested, so the document misrepresented MVP status as "nothing done". This reconciles the checklist with the actual implementation.

- **Checked (30 items)** — every endpoint and DTO confirmed present in source:
  - Environment / Grid / Location / Entity-read / Debug endpoints → mappings verified in the respective controllers.
  - All 6 DTOs → classes verified under `src/main/java/preponderous/viron/dto/` (`EnvironmentDto`, `CreateEnvironmentRequest`, `UpdateEnvironmentNameRequest`, `GridDto`, `LocationDto`, `EntityDto`).
- **Left unchecked (1 item)** — `POST /api/v1/entities`: implemented as `POST /api/v1/entities/{name}` (path variable, `EntityController:67`), **not** the request-body form the checklist documents. Annotated inline with a pointer to **#135**, which tracks that alignment.
- Added a short **status note** under the intro pointing at #135 as the remaining gap.

## Verification
Each checked box was confirmed against the controller `@*Mapping` annotations and the `dto/` directory — not from memory. The single unchecked item was confirmed to still diverge (path variable vs. body).

## Test plan
- [x] Docs-only change; no code touched. Checklist now shows 30/31 done with the one open item cross-referenced to #135.

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_