### PR TITLE
feat(security): require JWT authentication on the Viron API (#149)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+
+        <!-- JWT bearer-token authentication: validates tokens issued by UserAuth (issue #149). -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/preponderous/viron/config/SecurityConfig.java
+++ b/src/main/java/preponderous/viron/config/SecurityConfig.java
@@ -1,0 +1,84 @@
+// Copyright (c) 2024 Preponderous Software
+// MIT License
+
+package preponderous.viron.config;
+
+import java.nio.charset.StandardCharsets;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Secures the Viron REST API with JWT bearer-token authentication (issue #149).
+ *
+ * <p>Validates tokens issued by the <strong>UserAuth</strong> service: HMAC-signed
+ * (HS256/HS384/HS512) with a shared secret supplied via the {@code JWT_SECRET}
+ * environment variable, and an {@code iss} claim matching {@code app.jwt.issuer}
+ * (default {@code userauth}). The decoder configuration mirrors UserAuth's own, so a
+ * token minted there validates here without a network call.
+ *
+ * <p>All endpoints require a valid bearer token except actuator health and the
+ * OpenAPI/Swagger documentation. Sessions are stateless.
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET, "/actuator/health", "/actuator/health/**")
+                        .permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
+                        .permitAll()
+                        .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+        return http.build();
+    }
+
+    /**
+     * Builds a decoder for UserAuth's HMAC-signed JWTs. Mirrors UserAuth's
+     * {@code JwtConfig}: same secret-to-key derivation, the same MAC algorithm, and
+     * rejection of any token whose issuer does not match the configured value.
+     */
+    @Bean
+    JwtDecoder jwtDecoder(
+            @Value("${app.jwt.secret}") String secret,
+            @Value("${app.jwt.algorithm:HS256}") String algorithm,
+            @Value("${app.jwt.issuer:userauth}") String issuer) {
+        MacAlgorithm macAlgorithm = MacAlgorithm.from(algorithm);
+        if (macAlgorithm == null) {
+            throw new IllegalStateException(
+                    "Unsupported app.jwt.algorithm '" + algorithm
+                            + "'. Supported HMAC algorithms are: HS256, HS384, HS512.");
+        }
+        // MacAlgorithm "HS256" -> JCA name "HmacSHA256"
+        String jcaName = "HmacSHA" + macAlgorithm.getName().substring(2);
+        SecretKey key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), jcaName);
+        NimbusJwtDecoder decoder =
+                NimbusJwtDecoder.withSecretKey(key).macAlgorithm(macAlgorithm).build();
+        // Validate the issuer in addition to the default validators (signature, expiry).
+        OAuth2TokenValidator<Jwt> validator = JwtValidators.createDefaultWithIssuer(issuer);
+        decoder.setJwtValidator(validator);
+        return decoder;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,10 @@ database.dbPassword=postgres
 
 service.vironHost=http://localhost
 service.vironPort=9999
+
+# --- JWT authentication (validates tokens issued by the UserAuth service) ---
+# Shared HMAC secret; REQUIRED (no default — the app fails to start without it).
+# For HS256 it must be at least 32 bytes. Must match UserAuth's JWT_SECRET.
+app.jwt.secret=${JWT_SECRET}
+app.jwt.issuer=${JWT_ISSUER:userauth}
+app.jwt.algorithm=${JWT_ALGORITHM:HS256}

--- a/src/test/java/preponderous/viron/config/SecurityConfigTest.java
+++ b/src/test/java/preponderous/viron/config/SecurityConfigTest.java
@@ -1,0 +1,44 @@
+// Copyright (c) 2024 Preponderous Software
+// MIT License
+
+package preponderous.viron.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import preponderous.viron.database.DbInteractions;
+
+/**
+ * Verifies the JWT authentication added for issue #149: API endpoints reject
+ * unauthenticated requests, while actuator health stays public. (Authenticated
+ * access is exercised by the {@code @WithMockUser} controller tests.)
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DbInteractions dbInteractions;
+
+    @Test
+    void apiRequestWithoutTokenIsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/environments"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void actuatorHealthIsPublic() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/preponderous/viron/controllers/DebugControllerTest.java
+++ b/src/test/java/preponderous/viron/controllers/DebugControllerTest.java
@@ -3,6 +3,7 @@ package preponderous.viron.controllers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
@@ -33,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@WithMockUser
 @DirtiesContext
 class DebugControllerTest {
 

--- a/src/test/java/preponderous/viron/controllers/EntityControllerTest.java
+++ b/src/test/java/preponderous/viron/controllers/EntityControllerTest.java
@@ -3,6 +3,7 @@ package preponderous.viron.controllers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -29,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@WithMockUser
 @DirtiesContext
 class EntityControllerTest {
 

--- a/src/test/java/preponderous/viron/controllers/EnvironmentControllerTest.java
+++ b/src/test/java/preponderous/viron/controllers/EnvironmentControllerTest.java
@@ -3,6 +3,7 @@ package preponderous.viron.controllers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -30,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@WithMockUser
 @DirtiesContext
 class EnvironmentControllerTest {
 

--- a/src/test/java/preponderous/viron/controllers/GridControllerTest.java
+++ b/src/test/java/preponderous/viron/controllers/GridControllerTest.java
@@ -3,6 +3,7 @@ package preponderous.viron.controllers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@WithMockUser
 @DirtiesContext
 class GridControllerTest {
 

--- a/src/test/java/preponderous/viron/controllers/LocationControllerTest.java
+++ b/src/test/java/preponderous/viron/controllers/LocationControllerTest.java
@@ -3,6 +3,7 @@ package preponderous.viron.controllers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@WithMockUser
 class LocationControllerTest {
 
     @Autowired

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 Preponderous Software
+# MIT License
+#
+# Test configuration. Mirrors the runtime properties and supplies a fixed JWT secret
+# so the Spring context (which now requires app.jwt.secret) starts in tests.
+
+spring.application.name=viron
+server.port=9999
+
+database.dbUrl=jdbc:postgresql://localhost:5432/postgres
+database.dbUsername=postgres
+database.dbPassword=postgres
+
+service.vironHost=http://localhost
+service.vironPort=9999
+
+# Fixed test secret (>= 32 bytes for HS256). Not a real credential.
+app.jwt.secret=viron-test-jwt-secret-0123456789-abcdefghij
+app.jwt.issuer=userauth
+app.jwt.algorithm=HS256


### PR DESCRIPTION
## Summary
Closes #149. Viron exposed every endpoint **unauthenticated over plain HTTP** — an open read/write API to world state — contradicting the architecture (RFC 0001), which specifies JWT auth for all services. This adds JWT bearer-token authentication that validates tokens issued by **UserAuth**.

- **`SecurityConfig`** — a stateless Spring Security filter chain. All endpoints require a valid `Authorization: Bearer <token>` except `/actuator/health` and the OpenAPI/Swagger docs. The `JwtDecoder` mirrors UserAuth's own `JwtConfig` (HMAC HS256/384/512 with a shared secret + issuer validation), so a token minted by UserAuth validates here **with no network call** (fast, fits Viron's hot path).
- **Config** — `app.jwt.secret` (`${JWT_SECRET}`), `app.jwt.issuer` (default `userauth`), `app.jwt.algorithm` (default `HS256`).
- **Tests** — new `SecurityConfigTest` (unauthenticated → 401; health public); the five controller tests run as `@WithMockUser`.

## Validation
- [x] **Full suite green: 228 tests, 0 failures** via `./mvnw test` under JDK 21 (the CI command). Includes the new auth tests and all existing tests.

## ⚠️ Operational / breaking — please review before merge
- **Breaking:** every caller must now send a bearer token; previously-anonymous callers get `401`.
- **New required env var:** `JWT_SECRET` (no default — the app fails fast without it) and it **must match UserAuth's `JWT_SECRET`** (≥ 32 bytes for HS256). `JWT_ISSUER`/`JWT_ALGORITHM` default to `userauth`/`HS256`.
- **HTTPS** is assumed at the gateway, consistent with the other services (this PR adds the auth layer, not TLS termination).

Left for your review rather than auto-merged, given the breaking behavior and the new operational requirement.

## Possible follow-ups (not in this PR)
- Revocation-aware validation (calling UserAuth `GET /session/validate`) if you want logged-out tokens rejected before expiry — local HS256 validation was chosen for performance.
- Documenting `JWT_SECRET` in the README / a `.env.example` (Viron currently has neither).

Closes #149

_Opened by Claude on behalf of Daniel Stephenson; verified with `./mvnw test` (228 passing) under JDK 21._