### PR TITLE
feat(location): entity movement + occupancy/collision (#146, #147)

### DIFF
--- a/src/main/java/preponderous/viron/controllers/LocationController.java
+++ b/src/main/java/preponderous/viron/controllers/LocationController.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import preponderous.viron.dto.LocationDto;
+import preponderous.viron.exceptions.ConflictException;
+import preponderous.viron.exceptions.InvalidRequestException;
 import preponderous.viron.exceptions.NotFoundException;
 import preponderous.viron.exceptions.ServiceException;
 import preponderous.viron.mappers.LocationMapper;
@@ -14,6 +16,7 @@ import preponderous.viron.repositories.LocationRepository;
 
 import jakarta.validation.constraints.Min;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1/locations")
@@ -85,6 +88,50 @@ public class LocationController {
         }
         if (!locationRepository.removeEntityFromCurrentLocation(entityId)) {
             throw new ServiceException("Failed to remove entity " + entityId + " from current location");
+        }
+    }
+
+    @GetMapping("/{locationId}/entities")
+    public List<Integer> getEntityIdsAtLocation(@PathVariable @Min(1) int locationId) {
+        if (locationRepository.findById(locationId).isEmpty()) {
+            throw new NotFoundException("Location not found with id: " + locationId);
+        }
+        return locationRepository.getEntityIdsAtLocation(locationId);
+    }
+
+    @GetMapping("/{locationId}/occupied")
+    public boolean isLocationOccupied(@PathVariable @Min(1) int locationId) {
+        if (locationRepository.findById(locationId).isEmpty()) {
+            throw new NotFoundException("Location not found with id: " + locationId);
+        }
+        return !locationRepository.getEntityIdsAtLocation(locationId).isEmpty();
+    }
+
+    /**
+     * Moves an entity from its current location to {@code locationId}, validating that
+     * the entity is placed, the target exists and is in the same grid, and the target is
+     * not already occupied (collision). The transition itself is a single atomic update.
+     */
+    @PutMapping("/{locationId}/entity/{entityId}/move")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void moveEntityToLocation(@PathVariable("entityId") @Min(1) int entityId,
+                                     @PathVariable("locationId") @Min(1) int locationId) {
+        Location current = locationRepository.findByEntityId(entityId)
+                .orElseThrow(() -> new NotFoundException("Entity " + entityId + " is not placed at any location"));
+        if (locationRepository.findById(locationId).isEmpty()) {
+            throw new NotFoundException("Location not found with id: " + locationId);
+        }
+        Optional<Integer> currentGrid = locationRepository.getGridIdOfLocation(current.getLocationId());
+        Optional<Integer> targetGrid = locationRepository.getGridIdOfLocation(locationId);
+        if (currentGrid.isEmpty() || targetGrid.isEmpty() || !currentGrid.get().equals(targetGrid.get())) {
+            throw new InvalidRequestException(
+                    "Target location " + locationId + " is not in the same grid as entity " + entityId);
+        }
+        if (!locationRepository.getEntityIdsAtLocation(locationId).isEmpty()) {
+            throw new ConflictException("Target location " + locationId + " is already occupied");
+        }
+        if (!locationRepository.moveEntityToLocation(entityId, locationId)) {
+            throw new ServiceException("Failed to move entity " + entityId + " to location " + locationId);
         }
     }
 }

--- a/src/main/java/preponderous/viron/exceptions/ConflictException.java
+++ b/src/main/java/preponderous/viron/exceptions/ConflictException.java
@@ -1,0 +1,16 @@
+package preponderous.viron.exceptions;
+
+/**
+ * Thrown when a request cannot be completed because it conflicts with the current
+ * state — e.g. moving an entity onto an already-occupied location (a collision).
+ * Mapped to HTTP 409 Conflict.
+ */
+public class ConflictException extends ServiceException {
+    public ConflictException(String message) {
+        super(message);
+    }
+
+    public ConflictException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/preponderous/viron/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/preponderous/viron/exceptions/GlobalExceptionHandler.java
@@ -20,6 +20,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
     }
 
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ErrorResponse> handleConflictException(ConflictException ex) {
+        log.warn("Conflict: {}", ex.getMessage());
+        ErrorResponse error = new ErrorResponse(HttpStatus.CONFLICT.value(), ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+    }
+
     @ExceptionHandler(EntityCreationException.class)
     public ResponseEntity<ErrorResponse> handleEntityCreationException(EntityCreationException ex) {
         log.warn("Entity creation failed: {}", ex.getMessage());

--- a/src/main/java/preponderous/viron/repositories/LocationRepository.java
+++ b/src/main/java/preponderous/viron/repositories/LocationRepository.java
@@ -13,4 +13,13 @@ public interface LocationRepository {
     boolean addEntityToLocation(int entityId, int locationId);
     boolean removeEntityFromLocation(int entityId, int locationId);
     boolean removeEntityFromCurrentLocation(int entityId);
+
+    /** Entity ids currently placed at the given location (occupancy / collision query). */
+    List<Integer> getEntityIdsAtLocation(int locationId);
+
+    /** The grid a location belongs to, if any. */
+    Optional<Integer> getGridIdOfLocation(int locationId);
+
+    /** Atomically moves an entity's current placement to the target location. */
+    boolean moveEntityToLocation(int entityId, int targetLocationId);
 }

--- a/src/main/java/preponderous/viron/repositories/LocationRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/LocationRepositoryImpl.java
@@ -125,4 +125,41 @@ public class LocationRepositoryImpl implements LocationRepository {
         String query = "DELETE FROM viron.entity_location WHERE entity_id = " + entityId;
         return dbInteractions.update(query);
     }
+
+    @Override
+    public List<Integer> getEntityIdsAtLocation(int locationId) {
+        List<Integer> entityIds = new ArrayList<>();
+        String query = "SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId;
+        ResultSet rs = dbInteractions.query(query);
+        try {
+            while (rs != null && rs.next()) {
+                entityIds.add(rs.getInt("entity_id"));
+            }
+        } catch (SQLException e) {
+            log.error("Error getting entities at location: {}", e.getMessage());
+        }
+        return entityIds;
+    }
+
+    @Override
+    public Optional<Integer> getGridIdOfLocation(int locationId) {
+        String query = "SELECT grid_id FROM viron.location_grid WHERE location_id = " + locationId;
+        ResultSet rs = dbInteractions.query(query);
+        try {
+            if (rs != null && rs.next()) {
+                return Optional.of(rs.getInt("grid_id"));
+            }
+        } catch (SQLException e) {
+            log.error("Error getting grid of location: {}", e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean moveEntityToLocation(int entityId, int targetLocationId) {
+        // Single atomic statement: re-point the entity's existing placement to the target.
+        String query = "UPDATE viron.entity_location SET location_id = " + targetLocationId +
+                " WHERE entity_id = " + entityId;
+        return dbInteractions.update(query);
+    }
 }

--- a/src/test/java/preponderous/viron/controllers/LocationControllerTest.java
+++ b/src/test/java/preponderous/viron/controllers/LocationControllerTest.java
@@ -342,4 +342,111 @@ class LocationControllerTest {
                 .andExpect(jsonPath("$.status").value(500))
                 .andExpect(jsonPath("$.message").isString());
     }
+
+    // --- GET /api/v1/locations/{locationId}/entities (occupancy) ---
+
+    @Test
+    void getEntityIdsAtLocation_Success() throws Exception {
+        when(locationRepository.findById(5)).thenReturn(Optional.of(new Location(5, 1, 1)));
+        when(locationRepository.getEntityIdsAtLocation(5)).thenReturn(List.of(11, 22));
+
+        mockMvc.perform(get("/api/v1/locations/5/entities"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0]").value(11))
+                .andExpect(jsonPath("$[1]").value(22));
+    }
+
+    @Test
+    void getEntityIdsAtLocation_LocationNotFound() throws Exception {
+        when(locationRepository.findById(5)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/v1/locations/5/entities"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404));
+    }
+
+    // --- GET /api/v1/locations/{locationId}/occupied ---
+
+    @Test
+    void isLocationOccupied_TrueWhenEntitiesPresent() throws Exception {
+        when(locationRepository.findById(5)).thenReturn(Optional.of(new Location(5, 1, 1)));
+        when(locationRepository.getEntityIdsAtLocation(5)).thenReturn(List.of(11));
+
+        mockMvc.perform(get("/api/v1/locations/5/occupied"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("true"));
+    }
+
+    @Test
+    void isLocationOccupied_FalseWhenEmpty() throws Exception {
+        when(locationRepository.findById(5)).thenReturn(Optional.of(new Location(5, 1, 1)));
+        when(locationRepository.getEntityIdsAtLocation(5)).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/v1/locations/5/occupied"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("false"));
+    }
+
+    // --- PUT /api/v1/locations/{locationId}/entity/{entityId}/move ---
+
+    @Test
+    void moveEntityToLocation_Success() throws Exception {
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(5, 0, 0)));
+        when(locationRepository.findById(9)).thenReturn(Optional.of(new Location(9, 1, 0)));
+        when(locationRepository.getGridIdOfLocation(5)).thenReturn(Optional.of(3));
+        when(locationRepository.getGridIdOfLocation(9)).thenReturn(Optional.of(3));
+        when(locationRepository.getEntityIdsAtLocation(9)).thenReturn(Collections.emptyList());
+        when(locationRepository.moveEntityToLocation(1, 9)).thenReturn(true);
+
+        mockMvc.perform(put("/api/v1/locations/9/entity/1/move"))
+                .andExpect(status().isNoContent());
+
+        verify(locationRepository).moveEntityToLocation(1, 9);
+    }
+
+    @Test
+    void moveEntityToLocation_EntityNotPlaced() throws Exception {
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.empty());
+
+        mockMvc.perform(put("/api/v1/locations/9/entity/1/move"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Entity 1 is not placed at any location"));
+    }
+
+    @Test
+    void moveEntityToLocation_TargetNotFound() throws Exception {
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(5, 0, 0)));
+        when(locationRepository.findById(9)).thenReturn(Optional.empty());
+
+        mockMvc.perform(put("/api/v1/locations/9/entity/1/move"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Location not found with id: 9"));
+    }
+
+    @Test
+    void moveEntityToLocation_DifferentGridIsBadRequest() throws Exception {
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(5, 0, 0)));
+        when(locationRepository.findById(9)).thenReturn(Optional.of(new Location(9, 1, 0)));
+        when(locationRepository.getGridIdOfLocation(5)).thenReturn(Optional.of(3));
+        when(locationRepository.getGridIdOfLocation(9)).thenReturn(Optional.of(4));
+
+        mockMvc.perform(put("/api/v1/locations/9/entity/1/move"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void moveEntityToLocation_OccupiedTargetIsConflict() throws Exception {
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(5, 0, 0)));
+        when(locationRepository.findById(9)).thenReturn(Optional.of(new Location(9, 1, 0)));
+        when(locationRepository.getGridIdOfLocation(5)).thenReturn(Optional.of(3));
+        when(locationRepository.getGridIdOfLocation(9)).thenReturn(Optional.of(3));
+        when(locationRepository.getEntityIdsAtLocation(9)).thenReturn(List.of(99));
+
+        mockMvc.perform(put("/api/v1/locations/9/entity/1/move"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409));
+
+        verify(locationRepository, never()).moveEntityToLocation(anyInt(), anyInt());
+    }
 }

--- a/src/test/java/preponderous/viron/repositories/LocationRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/LocationRepositoryImplTest.java
@@ -259,4 +259,67 @@ public class LocationRepositoryImplTest {
         assertThat(repository.removeEntityFromCurrentLocation(42)).isTrue();
         Mockito.verify(dbInteractions).update(query);
     }
+
+    // ---- getEntityIdsAtLocation ----
+
+    @Test
+    public void testGetEntityIdsAtLocation_ReturnsIdsWhenResultSetNotEmpty() throws SQLException {
+        ResultSet rs = Mockito.mock(ResultSet.class);
+        Mockito.when(dbInteractions.query("SELECT entity_id FROM viron.entity_location WHERE location_id = 7"))
+                .thenReturn(rs);
+        Mockito.when(rs.next()).thenReturn(true, true, false);
+        Mockito.when(rs.getInt("entity_id")).thenReturn(11, 22);
+
+        LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
+
+        assertThat(repository.getEntityIdsAtLocation(7)).containsExactly(11, 22);
+    }
+
+    @Test
+    public void testGetEntityIdsAtLocation_ReturnsEmptyWhenResultSetNull() {
+        Mockito.when(dbInteractions.query(Mockito.anyString())).thenReturn(null);
+
+        LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
+
+        assertThat(repository.getEntityIdsAtLocation(7)).isEmpty();
+    }
+
+    // ---- getGridIdOfLocation ----
+
+    @Test
+    public void testGetGridIdOfLocation_ReturnsGridWhenPresent() throws SQLException {
+        ResultSet rs = Mockito.mock(ResultSet.class);
+        Mockito.when(dbInteractions.query("SELECT grid_id FROM viron.location_grid WHERE location_id = 5"))
+                .thenReturn(rs);
+        Mockito.when(rs.next()).thenReturn(true);
+        Mockito.when(rs.getInt("grid_id")).thenReturn(3);
+
+        LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
+
+        assertThat(repository.getGridIdOfLocation(5)).contains(3);
+    }
+
+    @Test
+    public void testGetGridIdOfLocation_EmptyWhenNoRow() throws SQLException {
+        ResultSet rs = Mockito.mock(ResultSet.class);
+        Mockito.when(dbInteractions.query(Mockito.anyString())).thenReturn(rs);
+        Mockito.when(rs.next()).thenReturn(false);
+
+        LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
+
+        assertThat(repository.getGridIdOfLocation(5)).isEmpty();
+    }
+
+    // ---- moveEntityToLocation ----
+
+    @Test
+    public void testMoveEntityToLocation_DelegatesToUpdate() {
+        String query = "UPDATE viron.entity_location SET location_id = 9 WHERE entity_id = 4";
+        Mockito.when(dbInteractions.update(query)).thenReturn(true);
+
+        LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
+
+        assertThat(repository.moveEntityToLocation(4, 9)).isTrue();
+        Mockito.verify(dbInteractions).update(query);
+    }
 }


### PR DESCRIPTION
## Summary
Closes #146 and #147 — two coupled Viron responsibilities from RFC 0001 that didn't exist: **validate and apply movement**, and **spatial queries / collision detection**. Movement validation is where the collision check lives, so they're delivered together.

### Occupancy / collision (#147)
- `LocationRepository.getEntityIdsAtLocation(locationId)` — the entity ids at a location.
- `GET /api/v1/locations/{locationId}/entities` — who's at a location.
- `GET /api/v1/locations/{locationId}/occupied` — boolean "is it occupied".

### Movement (#146)
- `LocationRepository.moveEntityToLocation(entityId, targetLocationId)` — a **single atomic `UPDATE`** that re-points the entity's placement (avoids the non-atomic remove-then-add the issue called out).
- `getGridIdOfLocation` — supports same-grid validation.
- `PUT /api/v1/locations/{locationId}/entity/{entityId}/move` — validates before moving:
  - entity is placed somewhere → else **404**
  - target location exists → else **404**
  - target is in the **same grid** as the entity's current location → else **400**
  - target is **unoccupied** (collision) → else **409**
- New `ConflictException` → HTTP **409** in `GlobalExceptionHandler`.

## Validation
- [x] **242 tests, 0 failures** via `./mvnw test` under JDK 21 (the CI command). +9 controller tests (each move/occupancy path) and +5 repository tests.
- Additive (new endpoints only); no existing behavior changed. New endpoints are covered by the JWT auth from #149 like all others.

## Scoped out (noted for follow-up)
- **Neighbors query** (`GET .../neighbors`) — #147 lists it as an example; deferred to keep this PR focused. Grid geometry (orthogonal adjacency from x,y) can be a small follow-up.
- **Adjacency enforcement on move** — the move allows any unoccupied cell in the same grid; step-by-step adjacency is a game-policy choice left open.

Closes #146
Closes #147

_Opened by Claude on behalf of Daniel Stephenson; verified with ./mvnw test (242 passing) under JDK 21._