### PR TITLE
fix: attach bearer token to in-repo client SDK requests

### DIFF
--- a/src/main/java/preponderous/viron/config/AuthTokenInterceptor.java
+++ b/src/main/java/preponderous/viron/config/AuthTokenInterceptor.java
@@ -1,0 +1,32 @@
+package preponderous.viron.config;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+
+/**
+ * Attaches the configured bearer token (service.authToken) to outgoing requests
+ * made by the in-repo client SDKs. If no token is configured, requests are sent
+ * unmodified.
+ */
+public class AuthTokenInterceptor implements ClientHttpRequestInterceptor {
+    private final ServiceConfig serviceConfig;
+
+    public AuthTokenInterceptor(ServiceConfig serviceConfig) {
+        this.serviceConfig = serviceConfig;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        String authToken = serviceConfig.getAuthToken();
+        if (StringUtils.hasText(authToken)) {
+            request.getHeaders().set(HttpHeaders.AUTHORIZATION, "Bearer " + authToken);
+        }
+        return execution.execute(request, body);
+    }
+}

--- a/src/main/java/preponderous/viron/config/RestConfig.java
+++ b/src/main/java/preponderous/viron/config/RestConfig.java
@@ -8,7 +8,9 @@ import org.springframework.web.client.RestTemplate;
 public class RestConfig {
 
     @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
+    public RestTemplate restTemplate(ServiceConfig serviceConfig) {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors().add(new AuthTokenInterceptor(serviceConfig));
+        return restTemplate;
     }
 }

--- a/src/main/java/preponderous/viron/config/ServiceConfig.java
+++ b/src/main/java/preponderous/viron/config/ServiceConfig.java
@@ -12,4 +12,5 @@ import org.springframework.context.annotation.PropertySource;
 public class ServiceConfig {
     private String vironHost;
     private int vironPort;
+    private String authToken;
 }

--- a/src/main/java/preponderous/viron/services/EnvironmentService.java
+++ b/src/main/java/preponderous/viron/services/EnvironmentService.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import preponderous.viron.config.AuthTokenInterceptor;
 import preponderous.viron.config.ServiceConfig;
 import preponderous.viron.dto.CreateEnvironmentRequest;
 import preponderous.viron.dto.UpdateEnvironmentNameRequest;
@@ -28,7 +29,7 @@ public class EnvironmentService {
 
     @Autowired
     public EnvironmentService(RestTemplateBuilder restTemplateBuilder, ServiceConfig serviceConfig) {
-        this.restTemplateBuilder = restTemplateBuilder;
+        this.restTemplateBuilder = restTemplateBuilder.additionalInterceptors(new AuthTokenInterceptor(serviceConfig));
         this.serviceConfig = serviceConfig;
         this.baseUrl = this.serviceConfig.getVironHost() + ":" + serviceConfig.getVironPort() + "/api/v1/environments";
     }

--- a/src/main/java/preponderous/viron/services/GridService.java
+++ b/src/main/java/preponderous/viron/services/GridService.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+import preponderous.viron.config.AuthTokenInterceptor;
 import preponderous.viron.config.ServiceConfig;
 import preponderous.viron.exceptions.ServiceException;
 import preponderous.viron.models.Grid;
@@ -24,7 +25,7 @@ public class GridService {
 
     @Autowired
     public GridService(RestTemplateBuilder restTemplateBuilder, ServiceConfig serviceConfig) {
-        this.restTemplateBuilder = restTemplateBuilder;
+        this.restTemplateBuilder = restTemplateBuilder.additionalInterceptors(new AuthTokenInterceptor(serviceConfig));
         this.baseUrl = serviceConfig.getVironHost() + ":" + serviceConfig.getVironPort() + "/api/v1/grids";
     }
 

--- a/src/main/java/preponderous/viron/services/LocationService.java
+++ b/src/main/java/preponderous/viron/services/LocationService.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+import preponderous.viron.config.AuthTokenInterceptor;
 import preponderous.viron.config.ServiceConfig;
 import preponderous.viron.exceptions.NotFoundException;
 import preponderous.viron.exceptions.ServiceException;
@@ -26,7 +27,7 @@ public class LocationService {
 
     @Autowired
     public LocationService(RestTemplateBuilder restTemplateBuilder, ServiceConfig serviceConfig) {
-        this.restTemplate = restTemplateBuilder.build();
+        this.restTemplate = restTemplateBuilder.additionalInterceptors(new AuthTokenInterceptor(serviceConfig)).build();
         this.baseUrl = serviceConfig.getVironHost() + ":" + serviceConfig.getVironPort() + "/api/v1/locations";
     }
 

--- a/src/main/python/preponderous/viron/services/entityService.py
+++ b/src/main/python/preponderous/viron/services/entityService.py
@@ -7,51 +7,55 @@ from src.main.python.preponderous.viron.models.entity import Entity
 logger = logging.getLogger(__name__)
 
 class EntityService:
-    def __init__(self, viron_host: str, viron_port: int):
+    def __init__(self, viron_host: str, viron_port: int, auth_token: Optional[str] = None):
         self.viron_host = viron_host
         self.viron_port = viron_port
+        self.auth_token = auth_token
 
     def get_base_url(self) -> str:
         return f"{self.viron_host}:{self.viron_port}/api/v1/entities"
 
+    def get_auth_headers(self) -> dict:
+        return {"Authorization": f"Bearer {self.auth_token}"} if self.auth_token else {}
+
     def get_all_entities(self) -> List[Entity]:
-        response = requests.get(self.get_base_url())
+        response = requests.get(self.get_base_url(), headers=self.get_auth_headers())
         response.raise_for_status()
         data = response.json()
         return [Entity(**entity) for entity in data] if data else []
 
     def get_entity_by_id(self, entity_id: int) -> Optional[Entity]:
-        response = requests.get(f"{self.get_base_url()}/{entity_id}")
+        response = requests.get(f"{self.get_base_url()}/{entity_id}", headers=self.get_auth_headers())
         response.raise_for_status()
         data = response.json()
         return Entity(**data) if data else None
 
     def get_entities_in_environment(self, environment_id: int) -> List[Entity]:
-        response = requests.get(f"{self.get_base_url()}/environment/{environment_id}")
+        response = requests.get(f"{self.get_base_url()}/environment/{environment_id}", headers=self.get_auth_headers())
         response.raise_for_status()
         data = response.json()
         return [Entity(**entity) for entity in data] if data else []
 
     def get_entities_in_grid(self, grid_id: int) -> List[Entity]:
-        response = requests.get(f"{self.get_base_url()}/grid/{grid_id}")
+        response = requests.get(f"{self.get_base_url()}/grid/{grid_id}", headers=self.get_auth_headers())
         response.raise_for_status()
         data = response.json()
         return [Entity(**entity) for entity in data] if data else []
 
     def get_entities_in_location(self, location_id: int) -> List[Entity]:
-        response = requests.get(f"{self.get_base_url()}/location/{location_id}")
+        response = requests.get(f"{self.get_base_url()}/location/{location_id}", headers=self.get_auth_headers())
         response.raise_for_status()
         data = response.json()
         return [Entity(**entity) for entity in data] if data else []
 
     def get_entities_not_in_any_location(self) -> List[Entity]:
-        response = requests.get(f"{self.get_base_url()}/unassigned")
+        response = requests.get(f"{self.get_base_url()}/unassigned", headers=self.get_auth_headers())
         response.raise_for_status()
         data = response.json()
         return [Entity(**entity) for entity in data] if data else []
 
     def create_entity(self, name: str) -> Entity:
-        response = requests.post(self.get_base_url(), json={"name": name})
+        response = requests.post(self.get_base_url(), json={"name": name}, headers=self.get_auth_headers())
         response.raise_for_status()
         data = response.json()
         if not data:
@@ -60,7 +64,7 @@ class EntityService:
 
     def delete_entity(self, entity_id: int) -> bool:
         try:
-            response = requests.delete(f"{self.get_base_url()}/{entity_id}")
+            response = requests.delete(f"{self.get_base_url()}/{entity_id}", headers=self.get_auth_headers())
             response.raise_for_status()
             return True
         except Exception as e:
@@ -69,7 +73,7 @@ class EntityService:
 
     def update_entity_name(self, entity_id: int, name: str) -> bool:
         try:
-            response = requests.patch(f"{self.get_base_url()}/{entity_id}/name", json={"name": name})
+            response = requests.patch(f"{self.get_base_url()}/{entity_id}/name", json={"name": name}, headers=self.get_auth_headers())
             response.raise_for_status()
             return True
         except Exception as e:

--- a/src/main/python/preponderous/viron/services/environmentService.py
+++ b/src/main/python/preponderous/viron/services/environmentService.py
@@ -2,49 +2,54 @@
 # Copyright (c) 2024 Preponderous Software
 # MIT License
 
+from typing import Optional
 import requests
 from src.main.python.preponderous.viron.models.environment import Environment
 
 class EnvironmentService:
-    def __init__(self, viron_host: str, viron_port: int):
+    def __init__(self, viron_host: str, viron_port: int, auth_token: Optional[str] = None):
         self.viron_host = viron_host
         self.viron_port = viron_port
+        self.auth_token = auth_token
 
     def get_base_url(self) -> str:
         return f"{self.viron_host}:{self.viron_port}/api/v1/environments"
 
+    def get_auth_headers(self) -> dict:
+        return {"Authorization": f"Bearer {self.auth_token}"} if self.auth_token else {}
+
     def get_all_environments(self) -> list[Environment]:
-        response = requests.get(f"{self.get_base_url()}")
+        response = requests.get(f"{self.get_base_url()}", headers=self.get_auth_headers())
         response.raise_for_status()
         return [Environment(**env) for env in response.json()]
 
     def get_environment_by_id(self, environment_id: int) -> Environment:
-        response = requests.get(f"{self.get_base_url()}/{environment_id}")
+        response = requests.get(f"{self.get_base_url()}/{environment_id}", headers=self.get_auth_headers())
         response.raise_for_status()
         return Environment(**response.json())
 
     def get_environment_by_name(self, name: str) -> Environment:
-        response = requests.get(f"{self.get_base_url()}/name/{name}")
+        response = requests.get(f"{self.get_base_url()}/name/{name}", headers=self.get_auth_headers())
         response.raise_for_status()
         return Environment(**response.json())
 
     def get_environment_of_entity(self, entity_id: int) -> Environment:
-        response = requests.get(f"{self.get_base_url()}/entity/{entity_id}")
+        response = requests.get(f"{self.get_base_url()}/entity/{entity_id}", headers=self.get_auth_headers())
         response.raise_for_status()
         return Environment(**response.json())
 
     def create_environment(self, name: str, num_grids: int, grid_size: int) -> Environment:
         payload = {"name": name, "numGrids": num_grids, "gridSize": grid_size}
-        response = requests.post(f"{self.get_base_url()}", json=payload)
+        response = requests.post(f"{self.get_base_url()}", json=payload, headers=self.get_auth_headers())
         response.raise_for_status()
         return Environment(**response.json())
 
     def delete_environment(self, environment_id: int) -> bool:
-        response = requests.delete(f"{self.get_base_url()}/{environment_id}")
+        response = requests.delete(f"{self.get_base_url()}/{environment_id}", headers=self.get_auth_headers())
         response.raise_for_status()
         return response.status_code == 200
 
     def update_environment_name(self, environment_id: int, name: str) -> bool:
-        response = requests.patch(f"{self.get_base_url()}/{environment_id}/name", json={"name": name})
+        response = requests.patch(f"{self.get_base_url()}/{environment_id}/name", json={"name": name}, headers=self.get_auth_headers())
         response.raise_for_status()
         return response.status_code == 200

--- a/src/main/python/preponderous/viron/services/gridService.py
+++ b/src/main/python/preponderous/viron/services/gridService.py
@@ -10,29 +10,33 @@ from src.main.python.preponderous.viron.models.grid import Grid
 logger = logging.getLogger(__name__)
 
 class GridService:
-    def __init__(self, viron_host: str, viron_port: int):
+    def __init__(self, viron_host: str, viron_port: int, auth_token: Optional[str] = None):
         self.viron_host = viron_host
         self.viron_port = viron_port
+        self.auth_token = auth_token
 
     def get_base_url(self) -> str:
         return f"{self.viron_host}:{self.viron_port}/api/v1/grids"
 
+    def get_auth_headers(self) -> dict:
+        return {"Authorization": f"Bearer {self.auth_token}"} if self.auth_token else {}
+
     def get_all_grids(self) -> List[Grid]:
-        response = requests.get(self.get_base_url())
+        response = requests.get(self.get_base_url(), headers=self.get_auth_headers())
         response.raise_for_status()
         return [Grid(**grid) for grid in response.json()]
 
     def get_grid_by_id(self, grid_id: int) -> Optional[Grid]:
-        response = requests.get(f"{self.get_base_url()}/{grid_id}")
+        response = requests.get(f"{self.get_base_url()}/{grid_id}", headers=self.get_auth_headers())
         response.raise_for_status()
         return Grid(**response.json())
 
     def get_grids_in_environment(self, environment_id: int) -> List[Grid]:
-        response = requests.get(f"{self.get_base_url()}/environment/{environment_id}")
+        response = requests.get(f"{self.get_base_url()}/environment/{environment_id}", headers=self.get_auth_headers())
         response.raise_for_status()
         return [Grid(**grid) for grid in response.json()]
 
     def get_grid_of_entity(self, entity_id: int) -> Optional[Grid]:
-        response = requests.get(f"{self.get_base_url()}/entity/{entity_id}")
+        response = requests.get(f"{self.get_base_url()}/entity/{entity_id}", headers=self.get_auth_headers())
         response.raise_for_status()
         return Grid(**response.json())

--- a/src/main/python/preponderous/viron/services/locationService.py
+++ b/src/main/python/preponderous/viron/services/locationService.py
@@ -5,56 +5,60 @@ from dataclasses import dataclass
 from src.main.python.preponderous.viron.models.location import Location
 
 class LocationService:
-    def __init__(self, viron_host: str, viron_port: int):
+    def __init__(self, viron_host: str, viron_port: int, auth_token: Optional[str] = None):
         self.viron_host = viron_host
         self.viron_port = viron_port
+        self.auth_token = auth_token
 
     def get_base_url(self) -> str:
         return f"{self.viron_host}:{self.viron_port}/api/v1/locations"
 
+    def get_auth_headers(self) -> dict:
+        return {"Authorization": f"Bearer {self.auth_token}"} if self.auth_token else {}
+
     def get_all_locations(self) -> List[Location]:
-        response = requests.get(self.get_base_url())
+        response = requests.get(self.get_base_url(), headers=self.get_auth_headers())
         response.raise_for_status()
         return [Location(**loc) for loc in response.json()]
 
     def get_location_by_id(self, id: int) -> Location:
-        response = requests.get(f"{self.get_base_url()}/{id}")
+        response = requests.get(f"{self.get_base_url()}/{id}", headers=self.get_auth_headers())
         if response.status_code == 404:
             raise Exception(f"Location not found with id: {id}")
         response.raise_for_status()
         return Location(**response.json())
 
     def get_locations_in_environment(self, environment_id: int) -> List[Location]:
-        response = requests.get(f"{self.get_base_url()}/environment/{environment_id}")
+        response = requests.get(f"{self.get_base_url()}/environment/{environment_id}", headers=self.get_auth_headers())
         response.raise_for_status()
         return [Location(**loc) for loc in response.json()]
 
     def get_locations_in_grid(self, grid_id: int) -> List[Location]:
-        response = requests.get(f"{self.get_base_url()}/grid/{grid_id}")
+        response = requests.get(f"{self.get_base_url()}/grid/{grid_id}", headers=self.get_auth_headers())
         response.raise_for_status()
         return [Location(**loc) for loc in response.json()]
 
     def get_location_of_entity(self, entity_id: int) -> Location:
-        response = requests.get(f"{self.get_base_url()}/entity/{entity_id}")
+        response = requests.get(f"{self.get_base_url()}/entity/{entity_id}", headers=self.get_auth_headers())
         if response.status_code == 404:
             raise Exception(f"Location not found for entity: {entity_id}")
         response.raise_for_status()
         return Location(**response.json())
 
     def add_entity_to_location(self, entity_id: int, location_id: int) -> None:
-        response = requests.put(f"{self.get_base_url()}/{location_id}/entity/{entity_id}")
+        response = requests.put(f"{self.get_base_url()}/{location_id}/entity/{entity_id}", headers=self.get_auth_headers())
         if response.status_code == 404:
             raise Exception("Location or entity not found")
         response.raise_for_status()
 
     def remove_entity_from_location(self, entity_id: int, location_id: int) -> None:
-        response = requests.delete(f"{self.get_base_url()}/{location_id}/entity/{entity_id}")
+        response = requests.delete(f"{self.get_base_url()}/{location_id}/entity/{entity_id}", headers=self.get_auth_headers())
         if response.status_code == 404:
             raise Exception("Location or entity not found")
         response.raise_for_status()
 
     def remove_entity_from_current_location(self, entity_id: int) -> None:
-        response = requests.delete(f"{self.get_base_url()}/entity/{entity_id}")
+        response = requests.delete(f"{self.get_base_url()}/entity/{entity_id}", headers=self.get_auth_headers())
         if response.status_code == 404:
             raise Exception("Entity not found")
         response.raise_for_status()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,10 @@ database.dbPassword=postgres
 
 service.vironHost=http://localhost
 service.vironPort=9999
+# Bearer token attached by the in-repo client SDKs (EnvironmentService, GridService,
+# LocationService, EntityService) to every outgoing request; empty means no
+# Authorization header is sent. Set to a token issued by the UserAuth service.
+service.authToken=${VIRON_CLIENT_AUTH_TOKEN:}
 
 # --- JWT authentication (validates tokens issued by the UserAuth service) ---
 # Shared HMAC secret; REQUIRED (no default — the app fails to start without it).

--- a/src/test/java/preponderous/viron/config/AuthTokenInterceptorTest.java
+++ b/src/test/java/preponderous/viron/config/AuthTokenInterceptorTest.java
@@ -1,0 +1,55 @@
+package preponderous.viron.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AuthTokenInterceptorTest {
+    private ServiceConfig serviceConfig;
+    private HttpRequest request;
+    private ClientHttpRequestExecution execution;
+    private byte[] body;
+
+    @BeforeEach
+    void setUp() {
+        serviceConfig = new ServiceConfig();
+        request = mock(HttpRequest.class);
+        execution = mock(ClientHttpRequestExecution.class);
+        body = new byte[0];
+        when(request.getHeaders()).thenReturn(new HttpHeaders());
+    }
+
+    @Test
+    void testAddsBearerTokenWhenConfigured() throws Exception {
+        serviceConfig.setAuthToken("test-token");
+        AuthTokenInterceptor interceptor = new AuthTokenInterceptor(serviceConfig);
+        ClientHttpResponse expectedResponse = mock(ClientHttpResponse.class);
+        when(execution.execute(any(), any())).thenReturn(expectedResponse);
+
+        ClientHttpResponse response = interceptor.intercept(request, body, execution);
+
+        assertEquals("Bearer test-token", request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION));
+        verify(execution).execute(request, body);
+        assertEquals(expectedResponse, response);
+    }
+
+    @Test
+    void testOmitsHeaderWhenNoTokenConfigured() throws Exception {
+        AuthTokenInterceptor interceptor = new AuthTokenInterceptor(serviceConfig);
+        when(execution.execute(any(), any())).thenReturn(mock(ClientHttpResponse.class));
+
+        interceptor.intercept(request, body, execution);
+
+        assertNull(request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION));
+    }
+}

--- a/src/test/java/preponderous/viron/config/ServiceConfigTest.java
+++ b/src/test/java/preponderous/viron/config/ServiceConfigTest.java
@@ -27,4 +27,11 @@ public class ServiceConfigTest {
         serviceConfig.setVironPort(9999);
         assert(serviceConfig.getVironPort() == 9999);
     }
+
+    @Test
+    void testGetAuthToken() {
+        ServiceConfig serviceConfig = new ServiceConfig();
+        serviceConfig.setAuthToken("test-token");
+        assert(serviceConfig.getAuthToken().equals("test-token"));
+    }
 }

--- a/src/test/python/preponderous/viron/services/test_entityService.py
+++ b/src/test/python/preponderous/viron/services/test_entityService.py
@@ -37,7 +37,7 @@ def test_get_all_entities_success(mock_get):
     entities = service.get_all_entities()
     assert len(entities) == 2
     assert isinstance(entities[0], Entity)
-    mock_get.assert_called_once_with(service.get_base_url())
+    mock_get.assert_called_once_with(service.get_base_url(), headers={})
 
 
 @patch('requests.get')
@@ -59,7 +59,7 @@ def test_get_entity_by_id_success(mock_get):
     entity = service.get_entity_by_id(1)
     assert isinstance(entity, Entity)
     assert entity.getEntityId() == 1
-    mock_get.assert_called_once_with(f"{service.get_base_url()}/1")
+    mock_get.assert_called_once_with(f"{service.get_base_url()}/1", headers={})
 
 
 @patch('requests.get')
@@ -70,7 +70,7 @@ def test_get_entities_in_environment_success(mock_get):
 
     entities = service.get_entities_in_environment(1)
     assert len(entities) == 2
-    mock_get.assert_called_once_with(f"{service.get_base_url()}/environment/1")
+    mock_get.assert_called_once_with(f"{service.get_base_url()}/environment/1", headers={})
 
 
 @patch('requests.get')
@@ -81,7 +81,7 @@ def test_get_entities_in_grid_success(mock_get):
 
     entities = service.get_entities_in_grid(1)
     assert len(entities) == 2
-    mock_get.assert_called_once_with(f"{service.get_base_url()}/grid/1")
+    mock_get.assert_called_once_with(f"{service.get_base_url()}/grid/1", headers={})
 
 
 @patch('requests.get')
@@ -92,7 +92,7 @@ def test_get_entities_in_location_success(mock_get):
 
     entities = service.get_entities_in_location(1)
     assert len(entities) == 2
-    mock_get.assert_called_once_with(f"{service.get_base_url()}/location/1")
+    mock_get.assert_called_once_with(f"{service.get_base_url()}/location/1", headers={})
 
 
 @patch('requests.get')
@@ -103,7 +103,7 @@ def test_get_entities_not_in_any_location_success(mock_get):
 
     entities = service.get_entities_not_in_any_location()
     assert len(entities) == 2
-    mock_get.assert_called_once_with(f"{service.get_base_url()}/unassigned")
+    mock_get.assert_called_once_with(f"{service.get_base_url()}/unassigned", headers={})
 
 
 @patch('requests.post')
@@ -115,7 +115,7 @@ def test_create_entity_success(mock_post):
     entity = service.create_entity("Entity1")
     assert isinstance(entity, Entity)
     assert entity.name == "Entity1"
-    mock_post.assert_called_once_with(service.get_base_url(), json={"name": "Entity1"})
+    mock_post.assert_called_once_with(service.get_base_url(), json={"name": "Entity1"}, headers={})
 
 
 @patch('requests.delete')
@@ -125,7 +125,7 @@ def test_delete_entity_success(mock_delete):
 
     result = service.delete_entity(1)
     assert result is True
-    mock_delete.assert_called_once_with(f"{service.get_base_url()}/1")
+    mock_delete.assert_called_once_with(f"{service.get_base_url()}/1", headers={})
 
 
 @patch('requests.patch')
@@ -135,7 +135,7 @@ def test_update_entity_name_success(mock_patch):
 
     result = service.update_entity_name(1, "NewName")
     assert result is True
-    mock_patch.assert_called_once_with(f"{service.get_base_url()}/1/name", json={"name": "NewName"})
+    mock_patch.assert_called_once_with(f"{service.get_base_url()}/1/name", json={"name": "NewName"}, headers={})
 
 
 # Error cases
@@ -157,4 +157,23 @@ def test_create_entity_null_response(mock_post):
     with pytest.raises(Exception) as exc_info:
         service.create_entity("Entity1")
     assert "Created entity response was null" in str(exc_info.value)
+
+
+def test_get_auth_headers_without_token():
+    assert service.get_auth_headers() == {}
+
+
+@patch('requests.get')
+def test_get_all_entities_sends_bearer_token(mock_get):
+    authed_service = EntityService("http://localhost", 9999, auth_token="test-token")
+    mock_response = Mock()
+    mock_response.json.return_value = []
+    mock_get.return_value = mock_response
+
+    authed_service.get_all_entities()
+
+    mock_get.assert_called_once_with(
+        authed_service.get_base_url(),
+        headers={"Authorization": "Bearer test-token"},
+    )
 

--- a/src/test/python/preponderous/viron/services/test_environmentService.py
+++ b/src/test/python/preponderous/viron/services/test_environmentService.py
@@ -33,7 +33,7 @@ def test_get_all_environments(mock_get):
     assert environments[0].getEnvironmentId() == 1
     assert environments[0].getName() == 'Environment1'
     assert environments[0].getCreationDate() == '2024-01-01'
-    mock_get.assert_called_once_with("http://localhost:9999/api/v1/environments")
+    mock_get.assert_called_once_with("http://localhost:9999/api/v1/environments", headers={})
 
 @patch('requests.get')
 def test_get_environment_by_id(mock_get):
@@ -51,7 +51,7 @@ def test_get_environment_by_id(mock_get):
     assert isinstance(environment, Environment)
     assert environment.getEnvironmentId() == 1
     assert environment.getName() == 'Environment1'
-    mock_get.assert_called_once_with("http://localhost:9999/api/v1/environments/1")
+    mock_get.assert_called_once_with("http://localhost:9999/api/v1/environments/1", headers={})
 
 @patch('requests.get')
 def test_get_environment_by_name(mock_get):
@@ -68,7 +68,7 @@ def test_get_environment_by_name(mock_get):
 
     assert isinstance(environment, Environment)
     assert environment.getName() == 'Environment1'
-    mock_get.assert_called_once_with("http://localhost:9999/api/v1/environments/name/Environment1")
+    mock_get.assert_called_once_with("http://localhost:9999/api/v1/environments/name/Environment1", headers={})
 
 @patch('requests.get')
 def test_get_environment_of_entity(mock_get):
@@ -85,7 +85,7 @@ def test_get_environment_of_entity(mock_get):
 
     assert isinstance(environment, Environment)
     assert environment.getEnvironmentId() == 1
-    mock_get.assert_called_once_with("http://localhost:9999/api/v1/environments/entity/1")
+    mock_get.assert_called_once_with("http://localhost:9999/api/v1/environments/entity/1", headers={})
 
 @patch('requests.post')
 def test_create_environment(mock_post):
@@ -105,6 +105,7 @@ def test_create_environment(mock_post):
     mock_post.assert_called_once_with(
         "http://localhost:9999/api/v1/environments",
         json={"name": "TestEnv", "numGrids": 10, "gridSize": 10},
+        headers={},
     )
 
 @patch('requests.delete')
@@ -117,7 +118,7 @@ def test_delete_environment(mock_delete):
     result = service.delete_environment(1)
 
     assert result is True
-    mock_delete.assert_called_once_with("http://localhost:9999/api/v1/environments/1")
+    mock_delete.assert_called_once_with("http://localhost:9999/api/v1/environments/1", headers={})
 
 @patch('requests.patch')
 def test_update_environment_name(mock_patch):
@@ -132,6 +133,7 @@ def test_update_environment_name(mock_patch):
     mock_patch.assert_called_once_with(
         "http://localhost:9999/api/v1/environments/1/name",
         json={"name": "NewName"},
+        headers={},
     )
 
 @patch('requests.get')
@@ -144,7 +146,7 @@ def test_get_all_environments_empty(mock_get):
     environments = service.get_all_environments()
 
     assert len(environments) == 0
-    mock_get.assert_called_once_with("http://localhost:9999/api/v1/environments")
+    mock_get.assert_called_once_with("http://localhost:9999/api/v1/environments", headers={})
 
 @patch('requests.get')
 def test_http_error_handling(mock_get):
@@ -164,3 +166,21 @@ def test_environment_validation():
 
     with pytest.raises(TypeError):
         Environment(1, 123, "2024-01-01")
+
+def test_get_auth_headers_without_token():
+    assert service.get_auth_headers() == {}
+
+@patch('requests.get')
+def test_get_all_environments_sends_bearer_token(mock_get):
+    authed_service = EnvironmentService("http://localhost", 9999, auth_token="test-token")
+    mock_response = Mock()
+    mock_response.json.return_value = []
+    mock_response.raise_for_status = Mock()
+    mock_get.return_value = mock_response
+
+    authed_service.get_all_environments()
+
+    mock_get.assert_called_once_with(
+        "http://localhost:9999/api/v1/environments",
+        headers={"Authorization": "Bearer test-token"},
+    )

--- a/src/test/python/preponderous/viron/services/test_gridService.py
+++ b/src/test/python/preponderous/viron/services/test_gridService.py
@@ -45,7 +45,7 @@ class TestGetAllGrids:
         assert grids[1].get_grid_id() == 2
         assert grids[1].get_rows() == 15
         assert grids[1].get_columns() == 25
-        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}")
+        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}", headers={})
 
     @patch('requests.get')
     def test_error(self, mock_get):
@@ -67,7 +67,7 @@ class TestGetGridById:
         assert grid.get_grid_id() == 1
         assert grid.get_rows() == 10
         assert grid.get_columns() == 20
-        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}/1")
+        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}/1", headers={})
 
     @patch('requests.get')
     def test_not_found(self, mock_get):
@@ -79,7 +79,7 @@ class TestGetGridById:
             grid = service.get_grid_by_id(1)
             assert grid is None
 
-        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}/1")
+        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}/1", headers={})
 
     @patch('requests.get')
     def test_error(self, mock_get):
@@ -104,7 +104,7 @@ class TestGetGridsInEnvironment:
         assert isinstance(grids[0], Grid)
         assert grids[0].get_grid_id() == 1
         assert grids[1].get_grid_id() == 2
-        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}/environment/1")
+        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}/environment/1", headers={})
 
     @patch('requests.get')
     def test_empty_list(self, mock_get, mock_response):
@@ -114,7 +114,7 @@ class TestGetGridsInEnvironment:
         grids = service.get_grids_in_environment(1)
 
         assert len(grids) == 0
-        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}/environment/1")
+        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}/environment/1", headers={})
 
     @patch('requests.get')
     def test_error(self, mock_get):
@@ -123,6 +123,23 @@ class TestGetGridsInEnvironment:
         with pytest.raises(Exception) as exc_info:
             service.get_grids_in_environment(1)
         assert str(exc_info.value) == "Test error"
+
+class TestAuthToken:
+    def test_get_auth_headers_without_token(self):
+        assert service.get_auth_headers() == {}
+
+    @patch('requests.get')
+    def test_get_all_grids_sends_bearer_token(self, mock_get, mock_response):
+        authed_service = GridService("http://localhost", 9999, auth_token="test-token")
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        authed_service.get_all_grids()
+
+        mock_get.assert_called_once_with(
+            f"{BASE_URL}{API_PATH}",
+            headers={"Authorization": "Bearer test-token"},
+        )
 
 class TestGetGridOfEntity:
     @patch('requests.get')
@@ -136,7 +153,7 @@ class TestGetGridOfEntity:
         assert grid.get_grid_id() == 1
         assert grid.get_rows() == 10
         assert grid.get_columns() == 20
-        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}/entity/1")
+        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}/entity/1", headers={})
 
     @patch('requests.get')
     def test_not_found(self, mock_get):
@@ -148,7 +165,7 @@ class TestGetGridOfEntity:
             grid = service.get_grid_of_entity(1)
             assert grid is None
 
-        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}/entity/1")
+        mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}/entity/1", headers={})
 
     @patch('requests.get')
     def test_error(self, mock_get):

--- a/src/test/python/preponderous/viron/services/test_locationService.py
+++ b/src/test/python/preponderous/viron/services/test_locationService.py
@@ -30,7 +30,7 @@ def test_get_all_locations(mock_get):
     locations = service.get_all_locations()
 
     assert len(locations) == 2
-    mock_get.assert_called_with("http://localhost:9999/api/v1/locations")
+    mock_get.assert_called_with("http://localhost:9999/api/v1/locations", headers={})
 
 @patch('requests.get')
 def test_get_location_by_id(mock_get):
@@ -41,7 +41,7 @@ def test_get_location_by_id(mock_get):
 
     location = service.get_location_by_id(1)
 
-    mock_get.assert_called_with("http://localhost:9999/api/v1/locations/1")
+    mock_get.assert_called_with("http://localhost:9999/api/v1/locations/1", headers={})
 
 @patch('requests.get')
 def test_get_location_by_id_not_found(mock_get):
@@ -65,7 +65,7 @@ def test_get_locations_in_environment(mock_get):
     locations = service.get_locations_in_environment(1)
 
     assert len(locations) == 2
-    mock_get.assert_called_with("http://localhost:9999/api/v1/locations/environment/1")
+    mock_get.assert_called_with("http://localhost:9999/api/v1/locations/environment/1", headers={})
 
 @patch('requests.get')
 def test_get_locations_in_grid(mock_get):
@@ -80,7 +80,7 @@ def test_get_locations_in_grid(mock_get):
     locations = service.get_locations_in_grid(1)
 
     assert len(locations) == 2
-    mock_get.assert_called_with("http://localhost:9999/api/v1/locations/grid/1")
+    mock_get.assert_called_with("http://localhost:9999/api/v1/locations/grid/1", headers={})
 
 @patch('requests.get')
 def test_get_location_of_entity(mock_get):
@@ -91,7 +91,7 @@ def test_get_location_of_entity(mock_get):
 
     location = service.get_location_of_entity(1)
 
-    mock_get.assert_called_with("http://localhost:9999/api/v1/locations/entity/1")
+    mock_get.assert_called_with("http://localhost:9999/api/v1/locations/entity/1", headers={})
 
 @patch('requests.put')
 def test_add_entity_to_location(mock_put):
@@ -101,7 +101,7 @@ def test_add_entity_to_location(mock_put):
 
     service.add_entity_to_location(1, 1)
 
-    mock_put.assert_called_with("http://localhost:9999/api/v1/locations/1/entity/1")
+    mock_put.assert_called_with("http://localhost:9999/api/v1/locations/1/entity/1", headers={})
 
 @patch('requests.delete')
 def test_remove_entity_from_location(mock_delete):
@@ -111,7 +111,7 @@ def test_remove_entity_from_location(mock_delete):
 
     service.remove_entity_from_location(1, 1)
 
-    mock_delete.assert_called_with("http://localhost:9999/api/v1/locations/1/entity/1")
+    mock_delete.assert_called_with("http://localhost:9999/api/v1/locations/1/entity/1", headers={})
 
 @patch('requests.delete')
 def test_remove_entity_from_current_location(mock_delete):
@@ -121,7 +121,7 @@ def test_remove_entity_from_current_location(mock_delete):
 
     service.remove_entity_from_current_location(1)
 
-    mock_delete.assert_called_with("http://localhost:9999/api/v1/locations/entity/1")
+    mock_delete.assert_called_with("http://localhost:9999/api/v1/locations/entity/1", headers={})
 
 @patch('requests.delete')
 def test_remove_entity_not_found(mock_delete):
@@ -131,3 +131,23 @@ def test_remove_entity_not_found(mock_delete):
 
     with pytest.raises(Exception):
         service.remove_entity_from_current_location(1)
+
+
+def test_get_auth_headers_without_token():
+    assert service.get_auth_headers() == {}
+
+
+@patch('requests.get')
+def test_get_all_locations_sends_bearer_token(mock_get):
+    authed_service = LocationService("http://localhost", 9999, auth_token="test-token")
+    mock_response = Mock()
+    mock_response.json.return_value = []
+    mock_response.raise_for_status = Mock()
+    mock_get.return_value = mock_response
+
+    authed_service.get_all_locations()
+
+    mock_get.assert_called_with(
+        "http://localhost:9999/api/v1/locations",
+        headers={"Authorization": "Bearer test-token"},
+    )


### PR DESCRIPTION
## Summary
- Since #149/#150 `SecurityConfig` requires authentication on all endpoints except `/actuator/health*` and Swagger paths, but neither in-repo client SDK sent an `Authorization` header, so every non-health call would 401.
- Adds `service.authToken` (Java, `ServiceConfig`) and `auth_token` (Python) as an optional bearer token. A new `AuthTokenInterceptor` attaches `Authorization: Bearer <token>` to every outgoing `RestTemplate` request when a token is configured; the Python SDKs attach the same header via a `get_auth_headers()` helper on each service.
- `EntityService` (Java) already used the shared `RestConfig`-provided `RestTemplate` bean, so it picks up the interceptor automatically; `EnvironmentService`, `GridService`, and `LocationService` each build their own `RestTemplate` via `RestTemplateBuilder` and now register the interceptor explicitly.
- `service.authToken` defaults to empty (`${VIRON_CLIENT_AUTH_TOKEN:}`) — no header is sent unless configured, matching the Python default of no token.

## Test plan
- [x] `./mvnw test -B` — could not run locally (`./mvnw`/`java` unavailable to this session); relying on CI (`.github/workflows/ci.yml`) as the authoritative signal, see below.
- [x] `python3 -m pytest` — 88 passed locally.

Closes #154

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
