### PR TITLE
Add LocationService movement/occupancy SDK wrappers, fix stale EnvironmentDTO spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Core responsibilities:
 
 ## 📦 Features (MVP Scope)
 
-The MVP implements the endpoints defined in `openapi/viron-api.json` and documented in `docs/MVP.md`.
+The MVP implements the endpoints defined in `docs/openapi/viron-api.json` and documented in `docs/MVP.md`.
 
 **Environment Management**
 - Create, retrieve, update (including renaming), and delete environments.
@@ -68,7 +68,7 @@ The MVP implements the endpoints defined in `openapi/viron-api.json` and documen
 - Generate sample environments, grids, locations, and entities.
 - Quickly create a world and place an entity for testing.
 
-> For detailed endpoint definitions and request/response formats, see `docs/MVP.md` and `openapi/viron-api.json`.
+> For detailed endpoint definitions and request/response formats, see `docs/MVP.md` and `docs/openapi/viron-api.json`.
 
 ---
 
@@ -127,7 +127,7 @@ API will be available at: http://localhost:8080
 
 Once running, you can view the interactive API docs:  
 http://localhost:8080/swagger-ui.html  
-or refer to the `openapi/viron-api.json` file.
+or refer to the `docs/openapi/viron-api.json` file.
 
 ---
 

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -2,7 +2,7 @@
 
 The **Minimum Viable Product (MVP)** for Viron establishes the core spatial simulation capabilities necessary to manage **environments**, **grids**, **locations**, and **entities** via a REST API.
 
-This document aligns with the [`../openapi/viron-api.json`](../openapi/viron-api.json) specification and serves as the implementation guide.
+This document aligns with the [`openapi/viron-api.json`](openapi/viron-api.json) specification and serves as the implementation guide.
 
 > **Status:** The endpoints and DTOs below are implemented and tested; the checked boxes reflect the current implementation. The remaining gap is aligning entity creation to a request-body contract, tracked in [#135](https://github.com/Preponderous-Software/viron/issues/135).
 
@@ -78,7 +78,7 @@ Deliver a working, tested API that supports:
 
 ## ✅ Completion Criteria
 
-- All endpoints in [`../openapi/viron-api.json`](../openapi/viron-api.json) implemented and tested.
+- All endpoints in [`openapi/viron-api.json`](openapi/viron-api.json) implemented and tested.
 - DTOs returned in responses, avoiding direct exposure of internal entity models.
 - Unit and integration tests covering all controllers and repositories.
 - Endpoints verified via Postman or Swagger UI.

--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -1,6 +1,6 @@
 # PLANNING.md — Viron MVP Issue Plan (Milestone-Oriented)
 
-This plan enumerates GitHub issues to implement the Viron MVP as defined in `../openapi/viron-api.json`, grouped into milestones with concise descriptions.
+This plan enumerates GitHub issues to implement the Viron MVP as defined in `openapi/viron-api.json`, grouped into milestones with concise descriptions.
 
 ---
 

--- a/docs/openapi/viron-api.json
+++ b/docs/openapi/viron-api.json
@@ -137,6 +137,44 @@
         }
       }
     },
+    "/api/v1/locations/environment/{environmentId}": {
+      "get": {
+        "summary": "Get locations in an environment",
+        "parameters": [{ "$ref": "#/components/parameters/EnvironmentIdParam" }],
+        "responses": {
+          "200": {
+            "description": "List of locations in the environment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/LocationDTO" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/locations/grid/{gridId}": {
+      "get": {
+        "summary": "Get locations in a grid",
+        "parameters": [{ "$ref": "#/components/parameters/GridIdParam" }],
+        "responses": {
+          "200": {
+            "description": "List of locations in the grid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/LocationDTO" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/locations/{locationId}/entity/{entityId}": {
       "put": {
         "summary": "Add entity to location",
@@ -155,7 +193,70 @@
         "responses": { "200": { "description": "Entity removed" } }
       }
     },
+    "/api/v1/locations/{locationId}/entity/{entityId}/move": {
+      "put": {
+        "summary": "Move an entity to an adjacent-in-grid, unoccupied location",
+        "parameters": [
+          { "$ref": "#/components/parameters/LocationIdParam" },
+          { "$ref": "#/components/parameters/EntityIdParam" }
+        ],
+        "responses": {
+          "204": { "description": "Entity moved" },
+          "400": { "description": "Target location is not in the same grid as the entity" },
+          "404": { "description": "Entity is not placed at any location, or target location not found" },
+          "409": { "description": "Target location is already occupied" }
+        }
+      }
+    },
+    "/api/v1/locations/{locationId}/entities": {
+      "get": {
+        "summary": "Get entity IDs at a location",
+        "parameters": [{ "$ref": "#/components/parameters/LocationIdParam" }],
+        "responses": {
+          "200": {
+            "description": "List of entity IDs at the location",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "type": "integer" }
+                }
+              }
+            }
+          },
+          "404": { "description": "Location not found" }
+        }
+      }
+    },
+    "/api/v1/locations/{locationId}/occupied": {
+      "get": {
+        "summary": "Check whether a location is occupied",
+        "parameters": [{ "$ref": "#/components/parameters/LocationIdParam" }],
+        "responses": {
+          "200": {
+            "description": "Whether the location is occupied",
+            "content": {
+              "application/json": { "schema": { "type": "boolean" } }
+            }
+          },
+          "404": { "description": "Location not found" }
+        }
+      }
+    },
     "/api/v1/locations/entity/{entityId}": {
+      "get": {
+        "summary": "Get the location of an entity",
+        "parameters": [{ "$ref": "#/components/parameters/EntityIdParam" }],
+        "responses": {
+          "200": {
+            "description": "Location of the entity",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/LocationDTO" } }
+            }
+          },
+          "404": { "description": "Location not found for entity" }
+        }
+      },
       "delete": {
         "summary": "Remove entity from current location",
         "parameters": [{ "$ref": "#/components/parameters/EntityIdParam" }],
@@ -339,8 +440,7 @@
         "properties": {
           "environmentId": { "type": "integer" },
           "name": { "type": "string" },
-          "width": { "type": "integer" },
-          "height": { "type": "integer" }
+          "creationDate": { "type": "string" }
         }
       },
       "CreateEnvironmentRequest": {

--- a/docs/openapi/viron-api.json
+++ b/docs/openapi/viron-api.json
@@ -195,7 +195,7 @@
     },
     "/api/v1/locations/{locationId}/entity/{entityId}/move": {
       "put": {
-        "summary": "Move an entity to an adjacent-in-grid, unoccupied location",
+        "summary": "Move an entity to an unoccupied location in the same grid",
         "parameters": [
           { "$ref": "#/components/parameters/LocationIdParam" },
           { "$ref": "#/components/parameters/EntityIdParam" }

--- a/src/main/java/preponderous/viron/services/LocationService.java
+++ b/src/main/java/preponderous/viron/services/LocationService.java
@@ -11,6 +11,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import preponderous.viron.config.AuthTokenInterceptor;
 import preponderous.viron.config.ServiceConfig;
+import preponderous.viron.exceptions.ConflictException;
 import preponderous.viron.exceptions.NotFoundException;
 import preponderous.viron.exceptions.ServiceException;
 import preponderous.viron.models.Location;
@@ -177,6 +178,72 @@ public class LocationService {
         } catch (Exception e) {
             log.error("Error removing entity {} from current location: {}", entityId, e.getMessage());
             throw new ServiceException("Error removing entity from current location", e);
+        }
+    }
+
+    public List<Integer> getEntityIdsAtLocation(int locationId) {
+        try {
+            ResponseEntity<Integer[]> response = restTemplate.getForEntity(
+                    baseUrl + "/{locationId}/entities",
+                    Integer[].class,
+                    locationId
+            );
+            return response.getStatusCode() == HttpStatus.OK && response.getBody() != null
+                    ? Arrays.asList(response.getBody())
+                    : Collections.emptyList();
+        } catch (HttpClientErrorException.NotFound e) {
+            throw new NotFoundException("Location not found with id: " + locationId);
+        } catch (Exception e) {
+            log.error("Error getting entity ids at location {}: {}", locationId, e.getMessage());
+            throw new ServiceException("Error getting entity ids at location: " + locationId, e);
+        }
+    }
+
+    public boolean isLocationOccupied(int locationId) {
+        try {
+            ResponseEntity<Boolean> response = restTemplate.getForEntity(
+                    baseUrl + "/{locationId}/occupied",
+                    Boolean.class,
+                    locationId
+            );
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                return response.getBody();
+            }
+            throw new ServiceException("Failed to check occupancy for location: " + locationId);
+        } catch (HttpClientErrorException.NotFound e) {
+            throw new NotFoundException("Location not found with id: " + locationId);
+        } catch (Exception e) {
+            log.error("Error checking occupancy for location {}: {}", locationId, e.getMessage());
+            throw new ServiceException("Error checking occupancy for location: " + locationId, e);
+        }
+    }
+
+    public void moveEntityToLocation(int entityId, int locationId) {
+        try {
+            ResponseEntity<Void> response = restTemplate.exchange(
+                    baseUrl + "/{locationId}/entity/{entityId}/move",
+                    HttpMethod.PUT,
+                    null,
+                    Void.class,
+                    locationId,
+                    entityId
+            );
+            if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
+                throw new NotFoundException("Entity or location not found");
+            }
+            if (response.getStatusCode() == HttpStatus.CONFLICT) {
+                throw new ConflictException("Target location " + locationId + " is already occupied");
+            }
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new ServiceException("Failed to move entity to location");
+            }
+        } catch (HttpClientErrorException.NotFound e) {
+            throw new NotFoundException("Entity or location not found");
+        } catch (HttpClientErrorException.Conflict e) {
+            throw new ConflictException("Target location " + locationId + " is already occupied");
+        } catch (Exception e) {
+            log.error("Error moving entity {} to location {}: {}", entityId, locationId, e.getMessage());
+            throw new ServiceException("Error moving entity to location", e);
         }
     }
 }

--- a/src/main/python/preponderous/viron/services/locationService.py
+++ b/src/main/python/preponderous/viron/services/locationService.py
@@ -62,3 +62,25 @@ class LocationService:
         if response.status_code == 404:
             raise Exception("Entity not found")
         response.raise_for_status()
+
+    def get_entity_ids_at_location(self, location_id: int) -> List[int]:
+        response = requests.get(f"{self.get_base_url()}/{location_id}/entities", headers=self.get_auth_headers())
+        if response.status_code == 404:
+            raise Exception(f"Location not found with id: {location_id}")
+        response.raise_for_status()
+        return response.json()
+
+    def is_location_occupied(self, location_id: int) -> bool:
+        response = requests.get(f"{self.get_base_url()}/{location_id}/occupied", headers=self.get_auth_headers())
+        if response.status_code == 404:
+            raise Exception(f"Location not found with id: {location_id}")
+        response.raise_for_status()
+        return response.json()
+
+    def move_entity_to_location(self, entity_id: int, location_id: int) -> None:
+        response = requests.put(f"{self.get_base_url()}/{location_id}/entity/{entity_id}/move", headers=self.get_auth_headers())
+        if response.status_code == 404:
+            raise Exception("Entity or location not found")
+        if response.status_code == 409:
+            raise Exception(f"Target location {location_id} is already occupied")
+        response.raise_for_status()

--- a/src/test/python/preponderous/viron/services/test_locationService.py
+++ b/src/test/python/preponderous/viron/services/test_locationService.py
@@ -133,6 +133,80 @@ def test_remove_entity_not_found(mock_delete):
         service.remove_entity_from_current_location(1)
 
 
+@patch('requests.get')
+def test_get_entity_ids_at_location(mock_get):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [1, 2, 3]
+    mock_response.raise_for_status = Mock()
+    mock_get.return_value = mock_response
+
+    entity_ids = service.get_entity_ids_at_location(1)
+
+    assert entity_ids == [1, 2, 3]
+    mock_get.assert_called_with("http://localhost:9999/api/v1/locations/1/entities", headers={})
+
+@patch('requests.get')
+def test_get_entity_ids_at_location_not_found(mock_get):
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_get.return_value = mock_response
+
+    with pytest.raises(Exception):
+        service.get_entity_ids_at_location(1)
+
+@patch('requests.get')
+def test_is_location_occupied(mock_get):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = True
+    mock_response.raise_for_status = Mock()
+    mock_get.return_value = mock_response
+
+    occupied = service.is_location_occupied(1)
+
+    assert occupied is True
+    mock_get.assert_called_with("http://localhost:9999/api/v1/locations/1/occupied", headers={})
+
+@patch('requests.get')
+def test_is_location_occupied_not_found(mock_get):
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_get.return_value = mock_response
+
+    with pytest.raises(Exception):
+        service.is_location_occupied(1)
+
+@patch('requests.put')
+def test_move_entity_to_location(mock_put):
+    mock_response = Mock()
+    mock_response.status_code = 204
+    mock_response.raise_for_status = Mock()
+    mock_put.return_value = mock_response
+
+    service.move_entity_to_location(1, 2)
+
+    mock_put.assert_called_with("http://localhost:9999/api/v1/locations/2/entity/1/move", headers={})
+
+@patch('requests.put')
+def test_move_entity_to_location_not_found(mock_put):
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_put.return_value = mock_response
+
+    with pytest.raises(Exception):
+        service.move_entity_to_location(1, 2)
+
+@patch('requests.put')
+def test_move_entity_to_location_conflict(mock_put):
+    mock_response = Mock()
+    mock_response.status_code = 409
+    mock_put.return_value = mock_response
+
+    with pytest.raises(Exception):
+        service.move_entity_to_location(1, 2)
+
+
 def test_get_auth_headers_without_token():
     assert service.get_auth_headers() == {}
 


### PR DESCRIPTION
## Summary
- Add `getEntityIdsAtLocation` / `isLocationOccupied` / `moveEntityToLocation` to both the Java (`LocationService.java`) and Python (`locationService.py`) client SDKs, bringing `LocationService` into 1:1 parity with `LocationController` — the same convention already followed by `EntityService`/`EnvironmentService` in both languages.
- Document the three movement/occupancy endpoints, plus the previously entirely-undocumented `GET /locations/environment/{environmentId}`, `GET /locations/grid/{gridId}`, and `GET /locations/entity/{entityId}` endpoints, in `docs/openapi/viron-api.json` (they existed in `LocationController` but had no spec entries at all).
- Fix the stale `EnvironmentDTO` schema in the OpenAPI spec — it still listed `width`/`height`, which `EnvironmentDto.java` never has; the actual field is `creationDate`.

## Test plan
- [x] `python3 -m pytest src/test/python` — 95 passed (new `LocationService` movement/occupancy tests included)
- [ ] `./mvnw test -B` — not runnable in this sandboxed session (`java`/`mvn` execution requires approval with no human available); relying on CI for this run's authoritative signal
- [x] Validated `docs/openapi/viron-api.json` is well-formed JSON and every `LocationController` endpoint now has a matching spec path

Closes #157
Closes #153

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
