### PR TITLE
docs: align MVP checklist, README tech stack, and OpenAPI spec with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,14 @@ The MVP implements the endpoints defined in `docs/openapi/viron-api.json` and do
 - Java 21
 - Spring Boot 3
 - Lombok
+- MapStruct (model ↔ DTO mapping)
+- Spring Security (OAuth2 resource server / JWT)
 - PostgreSQL (persistence layer)
 - Maven (build tool)
 - Docker + Docker Compose (deployment)
 - Swagger/OpenAPI (API documentation)
 - JaCoCo (test coverage)
-- Spotless/Checkstyle (code quality)
-- Optional: MapStruct, Flyway (future migrations)
+- Planned: Flyway (future migrations); schema currently comes from `db-scripts/setup/`
 
 ---
 
@@ -95,17 +96,24 @@ The MVP implements the endpoints defined in `docs/openapi/viron-api.json` and do
 
 viron/  
  ├── src/main/java/preponderous/viron/  
+ │    ├── config/            # Spring configuration (security, database, OpenAPI)  
  │    ├── controllers/       # REST controllers (Environment, Grid, Location, Entity, Debug)  
+ │    ├── database/          # JDBC access helpers  
  │    ├── dto/               # Data Transfer Objects for API requests/responses to keep internal models private  
+ │    ├── exceptions/        # Exception types and the global exception handler  
+ │    ├── factories/         # Creation logic for environments and entities  
+ │    ├── mappers/           # MapStruct mappers between models and DTOs  
  │    ├── models/            # Internal domain models  
  │    ├── repositories/      # Data access layer  
- │    ├── services/          # Business logic  
- │    └── factories/         # Creation logic for environments and entities  
+ │    └── services/          # Business logic  
+ ├── src/main/python/        # Python client SDK  
  ├── src/test/java/...       # Unit and integration tests  
+ ├── db-scripts/             # SQL schema setup scripts  
  ├── docs/  
- │    └── MVP.md             # Implementation checklist for MVP  
- ├── openapi/  
- │    └── viron-api.json     # API specification  
+ │    ├── MVP.md             # Implementation checklist for MVP  
+ │    └── openapi/  
+ │         └── viron-api.json  # API specification  
+ ├── postman/                # Postman collection generated from the API specification  
  ├── pom.xml                 # Maven configuration  
  └── README.md               # This file  
 

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -2,9 +2,9 @@
 
 The **Minimum Viable Product (MVP)** for Viron establishes the core spatial simulation capabilities necessary to manage **environments**, **grids**, **locations**, and **entities** via a REST API.
 
-This document aligns with the [`openapi/viron-api.json`](openapi/viron-api.json) specification and serves as the implementation guide.
+This document aligns with the [`docs/openapi/viron-api.json`](openapi/viron-api.json) specification and serves as the implementation guide.
 
-> **Status:** The endpoints and DTOs below are implemented and tested; the checked boxes reflect the current implementation. The remaining gap is aligning entity creation to a request-body contract, tracked in [#135](https://github.com/Preponderous-Software/viron/issues/135).
+> **Status:** The MVP endpoint surface is complete. Every endpoint and DTO below is implemented, tested, and present in the OpenAPI specification; the checked boxes reflect the current implementation.
 
 ---
 
@@ -44,8 +44,13 @@ Deliver a working, tested API that supports:
 - [x] `GET /api/v1/locations/{id}` – Retrieve a location by ID.
 - [x] `GET /api/v1/locations/environment/{environmentId}` – Retrieve locations in an environment.
 - [x] `GET /api/v1/locations/grid/{gridId}` – Retrieve locations in a grid.
+- [x] `GET /api/v1/locations/grid/{gridId}/unoccupied` – Retrieve locations in a grid that hold no entities.
 - [x] `GET /api/v1/locations/entity/{entityId}` – Retrieve the location of a specific entity.
+- [x] `GET /api/v1/locations/{locationId}/entities` – Retrieve the IDs of the entities at a location.
+- [x] `GET /api/v1/locations/{locationId}/occupied` – Report whether a location holds any entities.
+- [x] `GET /api/v1/locations/{locationId}/neighbors` – Retrieve the locations adjacent to a location within its grid.
 - [x] `PUT /api/v1/locations/{locationId}/entity/{entityId}` – Add an entity to a location.
+- [x] `PUT /api/v1/locations/{locationId}/entity/{entityId}/move` – Move a placed entity to an adjacent, unoccupied location in the same grid.
 - [x] `DELETE /api/v1/locations/{locationId}/entity/{entityId}` – Remove an entity from a specific location.
 - [x] `DELETE /api/v1/locations/entity/{entityId}` – Remove an entity from its current location.
 
@@ -54,7 +59,12 @@ Deliver a working, tested API that supports:
 ### 4. **Entity Management**
 - [x] `GET /api/v1/entities` – Retrieve all entities.
 - [x] `GET /api/v1/entities/{id}` – Retrieve a specific entity by ID.
-- [x] `POST /api/v1/entities` – Create a new entity (request body: `{ "name": "..." }`).
+- [x] `GET /api/v1/entities/environment/{environmentId}` – Retrieve entities in an environment.
+- [x] `GET /api/v1/entities/grid/{gridId}` – Retrieve entities in a grid.
+- [x] `GET /api/v1/entities/location/{locationId}` – Retrieve entities at a location.
+- [x] `GET /api/v1/entities/unassigned` – Retrieve entities that are not placed at any location.
+- [x] `POST /api/v1/entities` – Create a new entity (JSON body: `name`).
+- [x] `PATCH /api/v1/entities/{id}/name` – Update entity name (JSON body: `name`).
 - [x] `DELETE /api/v1/entities/{id}` – Delete an entity.
 
 ---
@@ -72,17 +82,19 @@ Deliver a working, tested API that supports:
 ## 🧩 DTO Requirements
 
 - [x] **EnvironmentDTO** – Public representation of an environment.
-- [x] **CreateEnvironmentRequest** – Request body for creating environments (name, number of grids, grid size).
+- [x] **CreateEnvironmentRequest** – Request body for creating environments (name, number of grids, and grid dimensions as either `gridSize` or both `numRows` and `numColumns`).
 - [x] **UpdateEnvironmentNameRequest** – Request body for updating environment names.
 - [x] **GridDTO** – Public representation of a grid.
 - [x] **LocationDTO** – Public representation of a location.
 - [x] **EntityDTO** – Public representation of an entity.
+- [x] **CreateEntityRequest** – Request body for creating entities (name).
+- [x] **UpdateEntityNameRequest** – Request body for updating entity names.
 
 ---
 
 ## ✅ Completion Criteria
 
-- All endpoints in [`openapi/viron-api.json`](openapi/viron-api.json) implemented and tested.
+- All endpoints in [`docs/openapi/viron-api.json`](openapi/viron-api.json) implemented and tested.
 - DTOs returned in responses, avoiding direct exposure of internal entity models.
 - Unit and integration tests covering all controllers and repositories.
 - Endpoints verified via Postman or Swagger UI.

--- a/docs/openapi/viron-api.json
+++ b/docs/openapi/viron-api.json
@@ -60,6 +60,43 @@
         "responses": { "200": { "description": "Environment deleted" } }
       }
     },
+    "/api/v1/environments/name/{name}": {
+      "get": {
+        "summary": "Get environment by name",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Environment details",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/EnvironmentDTO" } }
+            }
+          },
+          "404": { "description": "Environment not found with that name" }
+        }
+      }
+    },
+    "/api/v1/environments/entity/{entityId}": {
+      "get": {
+        "summary": "Get the environment containing an entity",
+        "parameters": [{ "$ref": "#/components/parameters/EntityIdParam" }],
+        "responses": {
+          "200": {
+            "description": "Environment containing the entity",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/EnvironmentDTO" } }
+            }
+          },
+          "404": { "description": "Environment not found for entity" }
+        }
+      }
+    },
     "/api/v1/environments/{id}/name": {
       "patch": {
         "summary": "Update environment name",
@@ -102,6 +139,47 @@
               "application/json": { "schema": { "$ref": "#/components/schemas/GridDTO" } }
             }
           }
+        }
+      }
+    },
+    "/api/v1/grids/environment/{environmentId}": {
+      "get": {
+        "summary": "Get all grids in an environment",
+        "parameters": [
+          {
+            "name": "environmentId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of grids in the environment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/GridDTO" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/grids/entity/{entityId}": {
+      "get": {
+        "summary": "Get the grid containing an entity",
+        "parameters": [{ "$ref": "#/components/parameters/EntityIdParam" }],
+        "responses": {
+          "200": {
+            "description": "Grid containing the entity",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/GridDTO" } }
+            }
+          },
+          "404": { "description": "Grid not found for entity" }
         }
       }
     },

--- a/postman/Viron.postman_collection.json
+++ b/postman/Viron.postman_collection.json
@@ -123,6 +123,64 @@
           "response": []
         },
         {
+          "name": "GET /api/v1/environments/name/{name}",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "localhost:9999/api/v1/environments/name/:name",
+              "host": [
+                "localhost"
+              ],
+              "port": "9999",
+              "path": [
+                "api",
+                "v1",
+                "environments",
+                "name",
+                ":name"
+              ],
+              "variable": [
+                {
+                  "key": "name",
+                  "value": "example"
+                }
+              ]
+            },
+            "description": "Get environment by name"
+          },
+          "response": []
+        },
+        {
+          "name": "GET /api/v1/environments/entity/{entityId}",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "localhost:9999/api/v1/environments/entity/:entityId",
+              "host": [
+                "localhost"
+              ],
+              "port": "9999",
+              "path": [
+                "api",
+                "v1",
+                "environments",
+                "entity",
+                ":entityId"
+              ],
+              "variable": [
+                {
+                  "key": "entityId",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Get the environment containing an entity"
+          },
+          "response": []
+        },
+        {
           "name": "PATCH /api/v1/environments/{id}/name",
           "request": {
             "method": "PATCH",
@@ -216,6 +274,64 @@
               ]
             },
             "description": "Get grid by ID"
+          },
+          "response": []
+        },
+        {
+          "name": "GET /api/v1/grids/environment/{environmentId}",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "localhost:9999/api/v1/grids/environment/:environmentId",
+              "host": [
+                "localhost"
+              ],
+              "port": "9999",
+              "path": [
+                "api",
+                "v1",
+                "grids",
+                "environment",
+                ":environmentId"
+              ],
+              "variable": [
+                {
+                  "key": "environmentId",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Get all grids in an environment"
+          },
+          "response": []
+        },
+        {
+          "name": "GET /api/v1/grids/entity/{entityId}",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "localhost:9999/api/v1/grids/entity/:entityId",
+              "host": [
+                "localhost"
+              ],
+              "port": "9999",
+              "path": [
+                "api",
+                "v1",
+                "grids",
+                "entity",
+                ":entityId"
+              ],
+              "variable": [
+                {
+                  "key": "entityId",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Get the grid containing an entity"
           },
           "response": []
         }

--- a/postman/Viron.postman_collection.json
+++ b/postman/Viron.postman_collection.json
@@ -143,7 +143,7 @@
               "variable": [
                 {
                   "key": "name",
-                  "value": "example"
+                  "value": "1"
                 }
               ]
             },


### PR DESCRIPTION
## Summary

Documentation-only pass bringing three artifacts back in line with the code.

**OpenAPI spec + Postman collection (#164)** — added the four implemented endpoints that had no spec entry:
- `GET /api/v1/environments/name/{name}`
- `GET /api/v1/environments/entity/{entityId}`
- `GET /api/v1/grids/environment/{environmentId}`
- `GET /api/v1/grids/entity/{entityId}`

Each was added next to its siblings and matches the surrounding style. Errors are documented as `404` with a description only, which is the existing convention in this spec — there is no `ErrorResponse` schema in `components` today, so the issue's suggestion to `$ref` one was not applied (see note below). `postman/Viron.postman_collection.json` is generated from the spec, so the same four requests were added there; spec operations and collection requests are now a 1:1 match.

**`docs/MVP.md` (#165)** — the status note claimed a remaining gap tracked in #135, which PR #151 closed on 2026-06-14; it now states the MVP endpoint surface is complete. Added the ten implemented-but-unlisted endpoints (five entity, five location) and the `CreateEntityRequest` / `UpdateEntityNameRequest` DTOs. Updated `CreateEnvironmentRequest`'s description for the non-square-grid contract from #167.

**`README.md` (#166)** — dropped the Spotless/Checkstyle bullet (`pom.xml` configures only `spring-boot-maven-plugin`, `jacoco-maven-plugin`, and `maven-compiler-plugin`; there is no formatter config anywhere and CI runs only `./mvnw`). Moved MapStruct out of "Optional" into the main list — it is a declared dependency plus annotation processor backing the whole `mappers/` package — leaving Flyway as the only genuinely future item. Also added Spring Security, and corrected the Project Structure tree, which showed `openapi/` at the repo root (it lives at `docs/openapi/`) and omitted `config/`, `database/`, `exceptions/`, `mappers/`, `db-scripts/`, `postman/`, and the Python SDK.

## Not done

The spec documents error statuses with a description and no body schema, while `GlobalExceptionHandler` actually returns `ErrorResponse{status, message}`. Fixing that means adding the schema and wiring it through every error response, which is broader than these three issues — filed separately rather than folded in here.

## Test plan

- [x] Both edited JSON files parse (`json.load`).
- [x] Every controller `@*Mapping` in `src/main/java/preponderous/viron/controllers/` has a matching spec path/method, and vice versa — no drift in either direction.
- [x] Spec operations and Postman collection requests cross-check to an exact match (0 in spec only, 0 in collection only).
- [x] Python SDK checked for drift: `environmentService.py` and `gridService.py` already implement all four newly-specced endpoints, and no Java source changed this PR, so no SDK update is needed.
- [ ] `./mvnw test -B` — not runnable in this environment (no local JDK/Maven); no Java, resource, or test source is touched by this PR, so CI on this branch is the authoritative signal.

Closes #164
Closes #165
Closes #166

<!-- gardener-tend-dispatch -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
