### PR TITLE
docs: align OpenAPI error responses with the implementation, and fix SDK delete_environment

### DIFF
--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -89,6 +89,7 @@ Deliver a working, tested API that supports:
 - [x] **EntityDTO** – Public representation of an entity.
 - [x] **CreateEntityRequest** – Request body for creating entities (name).
 - [x] **UpdateEntityNameRequest** – Request body for updating entity names.
+- [x] **ErrorResponse** – Body returned for every 4xx and 5xx response (`status`, `message`).
 
 ---
 

--- a/docs/openapi/viron-api.json
+++ b/docs/openapi/viron-api.json
@@ -51,13 +51,27 @@
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/EnvironmentDTO" } }
             }
+          },
+          "404": {
+            "description": "Environment not found with that id",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
           }
         }
       },
       "delete": {
         "summary": "Delete environment",
         "parameters": [{ "$ref": "#/components/parameters/EnvironmentIdParam" }],
-        "responses": { "200": { "description": "Environment deleted" } }
+        "responses": {
+          "204": { "description": "Environment deleted" },
+          "404": {
+            "description": "Environment not found with that id",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
+        }
       }
     },
     "/api/v1/environments/name/{name}": {
@@ -78,7 +92,12 @@
               "application/json": { "schema": { "$ref": "#/components/schemas/EnvironmentDTO" } }
             }
           },
-          "404": { "description": "Environment not found with that name" }
+          "404": {
+            "description": "Environment not found with that name",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
         }
       }
     },
@@ -93,7 +112,12 @@
               "application/json": { "schema": { "$ref": "#/components/schemas/EnvironmentDTO" } }
             }
           },
-          "404": { "description": "Environment not found for entity" }
+          "404": {
+            "description": "Environment not found for entity",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
         }
       }
     },
@@ -107,7 +131,15 @@
             "application/json": { "schema": { "$ref": "#/components/schemas/UpdateEnvironmentNameRequest" } }
           }
         },
-        "responses": { "200": { "description": "Name updated" } }
+        "responses": {
+          "200": { "description": "Name updated" },
+          "404": {
+            "description": "Environment not found with that id",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
+        }
       }
     },
     "/api/v1/grids": {
@@ -137,6 +169,12 @@
             "description": "Grid details",
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/GridDTO" } }
+            }
+          },
+          "404": {
+            "description": "Grid not found with that id",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
             }
           }
         }
@@ -179,7 +217,12 @@
               "application/json": { "schema": { "$ref": "#/components/schemas/GridDTO" } }
             }
           },
-          "404": { "description": "Grid not found for entity" }
+          "404": {
+            "description": "Grid not found for entity",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
         }
       }
     },
@@ -210,6 +253,12 @@
             "description": "Location details",
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/LocationDTO" } }
+            }
+          },
+          "404": {
+            "description": "Location not found with that id",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
             }
           }
         }
@@ -288,7 +337,12 @@
               }
             }
           },
-          "404": { "description": "Location not found, or not in any grid" }
+          "404": {
+            "description": "Location not found, or not in any grid",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
         }
       }
     },
@@ -299,7 +353,15 @@
           { "$ref": "#/components/parameters/LocationIdParam" },
           { "$ref": "#/components/parameters/EntityIdParam" }
         ],
-        "responses": { "200": { "description": "Entity added" } }
+        "responses": {
+          "200": { "description": "Entity added" },
+          "404": {
+            "description": "Location not found with that id",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
+        }
       },
       "delete": {
         "summary": "Remove entity from location",
@@ -307,7 +369,15 @@
           { "$ref": "#/components/parameters/LocationIdParam" },
           { "$ref": "#/components/parameters/EntityIdParam" }
         ],
-        "responses": { "200": { "description": "Entity removed" } }
+        "responses": {
+          "204": { "description": "Entity removed" },
+          "404": {
+            "description": "Location not found with that id",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
+        }
       }
     },
     "/api/v1/locations/{locationId}/entity/{entityId}/move": {
@@ -319,9 +389,24 @@
         ],
         "responses": {
           "204": { "description": "Entity moved" },
-          "400": { "description": "Target location is not in the same grid as the entity, or is not adjacent to the entity's current location" },
-          "404": { "description": "Entity is not placed at any location, or target location not found" },
-          "409": { "description": "Target location is already occupied" }
+          "400": {
+            "description": "Target location is not in the same grid as the entity, or is not adjacent to the entity's current location",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          },
+          "404": {
+            "description": "Entity is not placed at any location, or target location not found",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          },
+          "409": {
+            "description": "Target location is already occupied",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
         }
       }
     },
@@ -341,7 +426,12 @@
               }
             }
           },
-          "404": { "description": "Location not found" }
+          "404": {
+            "description": "Location not found",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
         }
       }
     },
@@ -356,7 +446,12 @@
               "application/json": { "schema": { "type": "boolean" } }
             }
           },
-          "404": { "description": "Location not found" }
+          "404": {
+            "description": "Location not found",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
         }
       }
     },
@@ -371,13 +466,26 @@
               "application/json": { "schema": { "$ref": "#/components/schemas/LocationDTO" } }
             }
           },
-          "404": { "description": "Location not found for entity" }
+          "404": {
+            "description": "Location not found for entity",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
         }
       },
       "delete": {
         "summary": "Remove entity from current location",
         "parameters": [{ "$ref": "#/components/parameters/EntityIdParam" }],
-        "responses": { "200": { "description": "Entity removed" } }
+        "responses": {
+          "204": { "description": "Entity removed" },
+          "404": {
+            "description": "Location not found for entity",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
+        }
       }
     },
     "/api/v1/entities": {
@@ -425,13 +533,27 @@
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/EntityDTO" } }
             }
+          },
+          "404": {
+            "description": "Entity not found with that id",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
           }
         }
       },
       "delete": {
         "summary": "Delete entity",
         "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
-        "responses": { "204": { "description": "Entity deleted" } }
+        "responses": {
+          "204": { "description": "Entity deleted" },
+          "404": {
+            "description": "Entity not found with that id",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
+        }
       }
     },
     "/api/v1/entities/{id}/name": {
@@ -444,7 +566,15 @@
             "application/json": { "schema": { "$ref": "#/components/schemas/UpdateEntityNameRequest" } }
           }
         },
-        "responses": { "200": { "description": "Name updated" } }
+        "responses": {
+          "200": { "description": "Name updated" },
+          "404": {
+            "description": "Entity not found with that id",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
+        }
       }
     },
     "/api/v1/entities/environment/{environmentId}": {
@@ -527,10 +657,16 @@
         "summary": "Create sample environment and entities",
         "description": "Only available when viron.debug.enabled=true (environment variable VIRON_DEBUG_ENABLED); otherwise the controller is not registered and this path is not mapped.",
         "responses": {
-          "200": {
+          "201": {
             "description": "Sample environment created",
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/EnvironmentDTO" } }
+            }
+          },
+          "400": {
+            "description": "The generated environment has no grids, or has no location at the sampled coordinates",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
             }
           }
         }
@@ -542,10 +678,16 @@
         "description": "Only available when viron.debug.enabled=true (environment variable VIRON_DEBUG_ENABLED); otherwise the controller is not registered and this path is not mapped.",
         "parameters": [{ "$ref": "#/components/parameters/EnvironmentNameParam" }],
         "responses": {
-          "200": {
+          "201": {
             "description": "Entity created and placed",
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/EntityDTO" } }
+            }
+          },
+          "400": {
+            "description": "The generated environment has no grids, or has no location at the sampled coordinates",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
             }
           }
         }
@@ -612,6 +754,14 @@
         "type": "object",
         "required": ["name"],
         "properties": { "name": { "type": "string" } }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "description": "Standard error response body, returned for every 4xx and 5xx response.",
+        "properties": {
+          "status": { "type": "integer", "description": "HTTP status code" },
+          "message": { "type": "string", "description": "Error message describing what went wrong" }
+        }
       }
     },
     "parameters": {

--- a/src/main/python/preponderous/viron/services/environmentService.py
+++ b/src/main/python/preponderous/viron/services/environmentService.py
@@ -66,7 +66,7 @@ class EnvironmentService:
     def delete_environment(self, environment_id: int) -> bool:
         response = requests.delete(f"{self.get_base_url()}/{environment_id}", headers=self.get_auth_headers())
         response.raise_for_status()
-        return response.status_code == 200
+        return True
 
     def update_environment_name(self, environment_id: int, name: str) -> bool:
         response = requests.patch(f"{self.get_base_url()}/{environment_id}/name", json={"name": name}, headers=self.get_auth_headers())

--- a/src/test/python/preponderous/viron/services/test_environmentService.py
+++ b/src/test/python/preponderous/viron/services/test_environmentService.py
@@ -152,7 +152,7 @@ def test_create_environment_with_half_specified_dimensions_raises(mock_post):
 @patch('requests.delete')
 def test_delete_environment(mock_delete):
     mock_response = Mock()
-    mock_response.status_code = 200
+    mock_response.status_code = 204
     mock_response.raise_for_status = Mock()
     mock_delete.return_value = mock_response
 


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

Brings `docs/openapi/viron-api.json` in line with what the controllers and `GlobalExceptionHandler` actually do, and fixes one Python SDK bug that shared a root cause with the spec drift.

**Error bodies (#169)** — adds an `ErrorResponse` schema (`status`, `message`, matching `dto/ErrorResponse.java`) and references it from all 23 `4xx` responses. Previously every error response declared a `description` and no body, so the spec claimed a 404 came back empty.

**Wrong success statuses (#170)** — five operations documented a status their controller does not return:

| Endpoint | Was | Now |
|---|---|---|
| `DELETE /api/v1/environments/{id}` | 200 | 204 |
| `DELETE /api/v1/locations/{locationId}/entity/{entityId}` | 200 | 204 |
| `DELETE /api/v1/locations/entity/{entityId}` | 200 | 204 |
| `POST /api/v1/debug/create-sample-data` | 200 | 201 |
| `POST /api/v1/debug/create-world-and-place-entity/{environmentName}` | 200 | 201 |

**Undocumented failure modes (#171)** — adds the 11 missing `404`s (every place a controller throws `NotFoundException`) and the 2 missing `400`s on the debug endpoints (`InvalidRequestException`). Deliberately excluded, per that issue's scope note: the `400` that `@Min(1)` / `@Valid` can produce on nearly every endpoint — better done as one uniform sweep or via #130.

**Python SDK (#172)** — `EnvironmentService.delete_environment` returned `response.status_code == 200` for an endpoint that returns 204, so a successful delete reported `False`. It now returns `True` once `raise_for_status()` has passed, matching `EntityService.delete_entity`. Its test mocked `status_code = 200`, which is why the suite never caught it; the mock is now 204.

`docs/MVP.md`'s DTO checklist gains an `ErrorResponse` line, since the schema is now part of the documented contract.

No Java source changed.

## Test plan

- [x] `python3 -m pytest` — 101 passed
- [x] `docs/openapi/viron-api.json` parses as JSON; every `$ref` in the document resolves; every `4xx`/`5xx` response now carries `content.application/json.schema.$ref → ErrorResponse` (checked with a throwaway script, not committed)
- [x] Documented statuses diffed operation-by-operation against `@ResponseStatus` annotations and `throw new *Exception` sites in all five controllers
- [ ] `./mvnw test -B` — not runnable in this environment (no local JDK/Maven); relying on the CI workflow's `./mvnw compile -B` + `./mvnw test -B` on this branch. No Java files are touched, so this is a no-op regression check.

Closes #169
Closes #170
Closes #171
Closes #172

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
