### PR TITLE
refactor: replace ResultSet-returning DbInteractions.query with a RowMapper API

### DIFF
--- a/src/main/java/preponderous/viron/database/DbInteractions.java
+++ b/src/main/java/preponderous/viron/database/DbInteractions.java
@@ -9,7 +9,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -59,7 +58,8 @@ public class DbInteractions {
             }
         } catch (SQLException e) {
             log.error("Error executing query: {}", e.getMessage());
-            return Collections.emptyList();
+            // Discard any partially mapped rows rather than reporting a truncated result.
+            return new ArrayList<>();
         }
         return results;
     }

--- a/src/main/java/preponderous/viron/database/DbInteractions.java
+++ b/src/main/java/preponderous/viron/database/DbInteractions.java
@@ -8,9 +8,10 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-
-import javax.sql.rowset.CachedRowSet;
-import javax.sql.rowset.RowSetProvider;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,30 +35,59 @@ public class DbInteractions {
     }
 
     /**
-     * Execute a parameterized SELECT and return a disconnected result.
+     * Execute a parameterized SELECT and map every returned row.
      *
      * <p>The query is run through a {@link PreparedStatement} so caller-supplied
      * values are bound as parameters rather than concatenated into SQL. The
-     * statement and live result set are closed before returning; the rows are
-     * copied into a {@link CachedRowSet} so callers can read them without leaking
-     * JDBC resources.
+     * statement and result set are owned here and closed before returning, so no
+     * JDBC resource ever reaches the caller.
      *
      * @param query  SQL with {@code ?} placeholders for each parameter
+     * @param mapper maps each row to a result object
      * @param params values to bind to the placeholders, in order
-     * @return a disconnected {@link ResultSet} of the rows, or {@code null} on error
+     * @param <T>    mapped result type
+     * @return the mapped rows in result-set order, or an empty list if the query failed
      */
-    public ResultSet query(String query, Object... params) {
+    public <T> List<T> query(String query, RowMapper<T> mapper, Object... params) {
+        List<T> results = new ArrayList<>();
         try (PreparedStatement statement = connection.prepareStatement(query)) {
             bindParameters(statement, params);
             try (ResultSet rs = statement.executeQuery()) {
-                CachedRowSet cachedRowSet = RowSetProvider.newFactory().createCachedRowSet();
-                cachedRowSet.populate(rs);
-                return cachedRowSet;
+                while (rs.next()) {
+                    results.add(mapper.map(rs));
+                }
+            }
+        } catch (SQLException e) {
+            log.error("Error executing query: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+        return results;
+    }
+
+    /**
+     * Execute a parameterized SELECT and map its first row, if any.
+     *
+     * <p>Behaves like {@link #query(String, RowMapper, Object...)} but stops after the
+     * first row; any further rows the query happens to return are ignored.
+     *
+     * @param query  SQL with {@code ?} placeholders for each parameter
+     * @param mapper maps the first row to a result object
+     * @param params values to bind to the placeholders, in order
+     * @param <T>    mapped result type
+     * @return the mapped first row, or an empty {@link Optional} if there were no rows or the query failed
+     */
+    public <T> Optional<T> queryOne(String query, RowMapper<T> mapper, Object... params) {
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            bindParameters(statement, params);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.ofNullable(mapper.map(rs));
+                }
             }
         } catch (SQLException e) {
             log.error("Error executing query: {}", e.getMessage());
         }
-        return null;
+        return Optional.empty();
     }
 
     /**
@@ -106,5 +136,5 @@ public class DbInteractions {
         }
         return connection;
     }
-    
+
 }

--- a/src/main/java/preponderous/viron/database/RowMapper.java
+++ b/src/main/java/preponderous/viron/database/RowMapper.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2024 Preponderous Software
+// MIT License
+
+package preponderous.viron.database;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Maps the row a {@link ResultSet} is currently positioned on to a domain object.
+ *
+ * <p>Implementations must read only from the current row and must not advance the
+ * cursor — {@link DbInteractions} owns the iteration and closes the underlying JDBC
+ * resources.
+ *
+ * @param <T> type produced for each row
+ */
+@FunctionalInterface
+public interface RowMapper<T> {
+
+    /**
+     * Map the current row of {@code rs}.
+     *
+     * @param rs result set positioned on the row to map
+     * @return the mapped object
+     * @throws SQLException if a column cannot be read
+     */
+    T map(ResultSet rs) throws SQLException;
+}

--- a/src/main/java/preponderous/viron/factories/EntityFactory.java
+++ b/src/main/java/preponderous/viron/factories/EntityFactory.java
@@ -1,11 +1,8 @@
 package preponderous.viron.factories;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -41,17 +38,8 @@ public class EntityFactory {
     }
 
     private int getNextEntityId() {
-        ResultSet rs = dbInteractions.query("SELECT nextval('viron.entity_id_seq')");
-        if (rs == null) {
-            return -1;
-        }
-        try {
-            if (rs.next()) {
-                return rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            log.error("Error getting next entity id: {}", e.getMessage());
-        }
-        return -1;
+        Optional<Integer> nextId = dbInteractions.queryOne("SELECT nextval('viron.entity_id_seq')",
+                rs -> rs.getInt(1));
+        return nextId.orElse(-1);
     }
 }

--- a/src/main/java/preponderous/viron/factories/EnvironmentFactory.java
+++ b/src/main/java/preponderous/viron/factories/EnvironmentFactory.java
@@ -1,13 +1,10 @@
 package preponderous.viron.factories;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -113,47 +110,20 @@ public class EnvironmentFactory {
     }
 
     private int getNextEnvironmentId() {
-        ResultSet rs = dbInteractions.query("SELECT nextval('viron.environment_id_seq')");
-        if (rs == null) {
-            return -1;
-        }
-        try {
-            if (rs.next()) {
-                return rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            log.error("Error getting next environment id", e);
-        }
-        return -1;
+        Optional<Integer> nextId = dbInteractions.queryOne("SELECT nextval('viron.environment_id_seq')",
+                rs -> rs.getInt(1));
+        return nextId.orElse(-1);
     }
 
     private int getNextGridId() {
-        ResultSet rs = dbInteractions.query("SELECT nextval('viron.grid_id_seq')");
-        if (rs == null) {
-            return -1;
-        }
-        try {
-            if (rs.next()) {
-                return rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            log.error("Error getting next grid id", e);
-        }
-        return -1;
+        Optional<Integer> nextId = dbInteractions.queryOne("SELECT nextval('viron.grid_id_seq')",
+                rs -> rs.getInt(1));
+        return nextId.orElse(-1);
     }
 
     private int getNextLocationId() {
-        ResultSet rs = dbInteractions.query("SELECT nextval('viron.location_id_seq')");
-        if (rs == null) {
-            return -1;
-        }
-        try {
-            if (rs.next()) {
-                return rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            log.error("Error getting next location id", e);
-        }
-        return -1;
+        Optional<Integer> nextId = dbInteractions.queryOne("SELECT nextval('viron.location_id_seq')",
+                rs -> rs.getInt(1));
+        return nextId.orElse(-1);
     }
 }

--- a/src/main/java/preponderous/viron/repositories/EntityRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/EntityRepositoryImpl.java
@@ -1,18 +1,15 @@
 package preponderous.viron.repositories;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import preponderous.viron.database.DbInteractions;
 import preponderous.viron.models.Entity;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-@Slf4j
 public class EntityRepositoryImpl implements EntityRepository {
     private final DbInteractions dbInteractions;
 
@@ -29,124 +26,48 @@ public class EntityRepositoryImpl implements EntityRepository {
 
     @Override
     public List<Entity> findAll() {
-        List<Entity> entities = new ArrayList<>();
-        ResultSet rs = dbInteractions.query("SELECT * FROM viron.entity");
-        if (rs == null) {
-            log.error("Error getting entities: ResultSet is null");
-            return entities;
-        }
-        try {
-            while (rs.next()) {
-                entities.add(mapResultSetToEntity(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting entities: {}", e.getMessage());
-        }
-        return entities;
+        return dbInteractions.query("SELECT * FROM viron.entity", this::mapResultSetToEntity);
     }
 
     @Override
     public Optional<Entity> findById(int id) {
-        ResultSet rs = dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id = " + id);
-        if (rs == null) {
-            log.error("Error getting entity by id: ResultSet is null");
-            return Optional.empty();
-        }
-        try {
-            if (rs.next()) {
-                return Optional.of(mapResultSetToEntity(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting entity by id: {}", e.getMessage());
-        }
-        return Optional.empty();
+        return dbInteractions.queryOne("SELECT * FROM viron.entity WHERE entity_id = " + id,
+                this::mapResultSetToEntity);
     }
 
     @Override
     public List<Entity> findByEnvironmentId(int environmentId) {
-        List<Entity> entities = new ArrayList<>();
         String query = "SELECT * FROM viron.entity WHERE entity_id in " +
                 "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
                 "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))";
 
-        ResultSet rs = dbInteractions.query(query);
-        if (rs == null) {
-            log.error("Error getting entities in environment: ResultSet is null");
-            return entities;
-        }
-        try {
-            while (rs.next()) {
-                entities.add(mapResultSetToEntity(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting entities in environment: {}", e.getMessage());
-        }
-        return entities;
+        return dbInteractions.query(query, this::mapResultSetToEntity);
     }
 
     @Override
     public List<Entity> findByGridId(int gridId) {
-        List<Entity> entities = new ArrayList<>();
         String query = "SELECT * FROM viron.entity WHERE entity_id in " +
                 "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + "))";
 
-        ResultSet rs = dbInteractions.query(query);
-        if (rs == null) {
-            log.error("Error getting entities in grid: ResultSet is null");
-            return entities;
-        }
-        try {
-            while (rs.next()) {
-                entities.add(mapResultSetToEntity(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting entities in grid: {}", e.getMessage());
-        }
-        return entities;
+        return dbInteractions.query(query, this::mapResultSetToEntity);
     }
 
     @Override
     public List<Entity> findByLocationId(int locationId) {
-        List<Entity> entities = new ArrayList<>();
         String query = "SELECT * FROM viron.entity WHERE entity_id in " +
                 "(SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId + ")";
 
-        ResultSet rs = dbInteractions.query(query);
-        if (rs == null) {
-            log.error("Error getting entities in location: ResultSet is null");
-            return entities;
-        }
-        try {
-            while (rs.next()) {
-                entities.add(mapResultSetToEntity(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting entities in location: {}", e.getMessage());
-        }
-        return entities;
+        return dbInteractions.query(query, this::mapResultSetToEntity);
     }
 
     @Override
     public List<Entity> findEntitiesNotInAnyLocation() {
-        List<Entity> entities = new ArrayList<>();
         String query = "SELECT * FROM viron.entity WHERE entity_id not in " +
                 "(SELECT entity_id FROM viron.entity_location)";
 
-        ResultSet rs = dbInteractions.query(query);
-        if (rs == null) {
-            log.error("Error getting entities not in any location: ResultSet is null");
-            return entities;
-        }
-        try {
-            while (rs.next()) {
-                entities.add(mapResultSetToEntity(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting entities not in any location: {}", e.getMessage());
-        }
-        return entities;
+        return dbInteractions.query(query, this::mapResultSetToEntity);
     }
 
     @Override
@@ -155,14 +76,9 @@ public class EntityRepositoryImpl implements EntityRepository {
             String query = "INSERT INTO viron.entity (name, creation_date) VALUES (?, NOW())";
             if (dbInteractions.update(query, entity.getName())) {
                 // Get the last inserted id
-                ResultSet rs = dbInteractions.query("SELECT LAST_INSERT_ID()");
-                try {
-                    if (rs != null && rs.next()) {
-                        return findById(rs.getInt(1)).orElse(null);
-                    }
-                } catch (SQLException e) {
-                    log.error("Error getting last inserted id: {}", e.getMessage());
-                }
+                Optional<Integer> lastInsertedId =
+                        dbInteractions.queryOne("SELECT LAST_INSERT_ID()", rs -> rs.getInt(1));
+                return lastInsertedId.flatMap(this::findById).orElse(null);
             }
         }
         return null;

--- a/src/main/java/preponderous/viron/repositories/EnvironmentRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/EnvironmentRepositoryImpl.java
@@ -1,6 +1,5 @@
 package preponderous.viron.repositories;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import preponderous.viron.database.DbInteractions;
@@ -8,12 +7,10 @@ import preponderous.viron.models.Environment;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-@Slf4j
 public class EnvironmentRepositoryImpl implements EnvironmentRepository {
     private final DbInteractions dbInteractions;
 
@@ -24,71 +21,26 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
 
     @Override
     public List<Environment> findAll() {
-        List<Environment> environments = new ArrayList<>();
-        ResultSet rs = dbInteractions.query("SELECT * FROM viron.environment");
-        if (rs == null) {
-            log.error("Error finding all environments: ResultSet is null");
-            return environments;
-        }
-        try {
-            while (rs.next()) {
-                environments.add(mapResultSetToEnvironment(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error finding all environments: {}", e.getMessage());
-        }
-        return environments;
+        return dbInteractions.query("SELECT * FROM viron.environment", this::mapResultSetToEnvironment);
     }
 
     @Override
     public Optional<Environment> findById(int id) {
-        ResultSet rs = dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = " + id);
-        if (rs == null) {
-            log.error("Error finding environment by id: ResultSet is null");
-            return Optional.empty();
-        }
-        try {
-            if (rs.next()) {
-                return Optional.of(mapResultSetToEnvironment(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error finding environment by id: {}", e.getMessage());
-        }
-        return Optional.empty();
+        return dbInteractions.queryOne("SELECT * FROM viron.environment WHERE environment_id = " + id,
+                this::mapResultSetToEnvironment);
     }
 
     @Override
     public Optional<Environment> findByName(String name) {
-        ResultSet rs = dbInteractions.query("SELECT * FROM viron.environment WHERE name = ?", name);
-        if (rs == null) {
-            log.error("Error finding environment by name: ResultSet is null");
-            return Optional.empty();
-        }
-        try {
-            if (rs.next()) {
-                return Optional.of(mapResultSetToEnvironment(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error finding environment by name: {}", e.getMessage());
-        }
-        return Optional.empty();
+        return dbInteractions.queryOne("SELECT * FROM viron.environment WHERE name = ?",
+                this::mapResultSetToEnvironment, name);
     }
 
     @Override
     public Optional<Environment> findByEntityId(int entityId) {
-        ResultSet rs = dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")");
-        if (rs == null) {
-            log.error("Error finding environment by entity id: ResultSet is null");
-            return Optional.empty();
-        }
-        try {
-            if (rs.next()) {
-                return Optional.of(mapResultSetToEnvironment(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error finding environment by entity id: {}", e.getMessage());
-        }
-        return Optional.empty();
+        return dbInteractions.queryOne(
+                "SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")",
+                this::mapResultSetToEnvironment);
     }
 
     @Override
@@ -110,56 +62,23 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
 
     @Override
     public List<Integer> findEntityIdsByEnvironmentId(int environmentId) {
-        List<Integer> entityIds = new ArrayList<>();
-        ResultSet rs = dbInteractions.query("SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))");
-        if (rs == null) {
-            log.error("Error finding entity ids: ResultSet is null");
-            return entityIds;
-        }
-        try {
-            while (rs.next()) {
-                entityIds.add(rs.getInt("entity_id"));
-            }
-        } catch (SQLException e) {
-            log.error("Error finding entity ids: {}", e.getMessage());
-        }
-        return entityIds;
+        return dbInteractions.query(
+                "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))",
+                rs -> rs.getInt("entity_id"));
     }
 
     @Override
     public List<Integer> findLocationIdsByEnvironmentId(int environmentId) {
-        List<Integer> locationIds = new ArrayList<>();
-        ResultSet rs = dbInteractions.query("SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")");
-        if (rs == null) {
-            log.error("Error finding location ids: ResultSet is null");
-            return locationIds;
-        }
-        try {
-            while (rs.next()) {
-                locationIds.add(rs.getInt("location_id"));
-            }
-        } catch (SQLException e) {
-            log.error("Error finding location ids: {}", e.getMessage());
-        }
-        return locationIds;
+        return dbInteractions.query(
+                "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")",
+                rs -> rs.getInt("location_id"));
     }
 
     @Override
     public List<Integer> findGridIdsByEnvironmentId(int environmentId) {
-        List<Integer> gridIds = new ArrayList<>();
-        ResultSet rs = dbInteractions.query("SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId);
-        if (rs == null) {
-            log.error("Error finding grid ids: ResultSet is null");
-            return gridIds;
-        }
-        try {
-            while (rs.next()) {
-                gridIds.add(rs.getInt("grid_id"));
-            }
-        } catch (SQLException e) {
-            log.error("Error finding grid ids: {}", e.getMessage());
-        }
-        return gridIds;
+        return dbInteractions.query(
+                "SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId,
+                rs -> rs.getInt("grid_id"));
     }
 
     @Override

--- a/src/main/java/preponderous/viron/repositories/GridRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/GridRepositoryImpl.java
@@ -1,18 +1,15 @@
 package preponderous.viron.repositories;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import preponderous.viron.database.DbInteractions;
 import preponderous.viron.models.Grid;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-@Slf4j
 public class GridRepositoryImpl implements GridRepository {
     private final DbInteractions dbInteractions;
 
@@ -29,57 +26,19 @@ public class GridRepositoryImpl implements GridRepository {
 
     @Override
     public List<Grid> findAll() {
-        List<Grid> grids = new ArrayList<>();
-        ResultSet rs = dbInteractions.query("SELECT * FROM viron.grid");
-        if (rs == null) {
-            log.error("Error getting grids: ResultSet is null");
-            return grids;
-        }
-        try {
-            while (rs.next()) {
-                grids.add(mapResultSetToGrid(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting grids: {}", e.getMessage());
-        }
-        return grids;
+        return dbInteractions.query("SELECT * FROM viron.grid", this::mapResultSetToGrid);
     }
 
     @Override
     public Optional<Grid> findById(int id) {
-        ResultSet rs = dbInteractions.query("SELECT * FROM viron.grid WHERE grid_id = " + id);
-        if (rs == null) {
-            log.error("Error getting grid by id: ResultSet is null");
-            return Optional.empty();
-        }
-        try {
-            if (rs.next()) {
-                return Optional.of(mapResultSetToGrid(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting grid by id: {}", e.getMessage());
-        }
-        return Optional.empty();
+        return dbInteractions.queryOne("SELECT * FROM viron.grid WHERE grid_id = " + id, this::mapResultSetToGrid);
     }
 
     @Override
     public List<Grid> findByEnvironmentId(int environmentId) {
-        List<Grid> grids = new ArrayList<>();
         String query = "SELECT * FROM viron.grid WHERE grid_id in " +
                 "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")";
-        ResultSet rs = dbInteractions.query(query);
-        if (rs == null) {
-            log.error("Error getting grids for environment: ResultSet is null");
-            return grids;
-        }
-        try {
-            while (rs.next()) {
-                grids.add(mapResultSetToGrid(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting grids for environment: {}", e.getMessage());
-        }
-        return grids;
+        return dbInteractions.query(query, this::mapResultSetToGrid);
     }
 
     @Override
@@ -87,18 +46,6 @@ public class GridRepositoryImpl implements GridRepository {
         String query = "SELECT * FROM viron.grid WHERE grid_id in " +
                 "(SELECT grid_id FROM viron.location_grid WHERE location_id in " +
                 "(SELECT location_id FROM viron.entity_location WHERE entity_id = " + entityId + "))";
-        ResultSet rs = dbInteractions.query(query);
-        if (rs == null) {
-            log.error("Error getting grid of entity: ResultSet is null");
-            return Optional.empty();
-        }
-        try {
-            if (rs.next()) {
-                return Optional.of(mapResultSetToGrid(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting grid of entity: {}", e.getMessage());
-        }
-        return Optional.empty();
+        return dbInteractions.queryOne(query, this::mapResultSetToGrid);
     }
 }

--- a/src/main/java/preponderous/viron/repositories/LocationRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/LocationRepositoryImpl.java
@@ -1,18 +1,15 @@
 package preponderous.viron.repositories;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import preponderous.viron.database.DbInteractions;
 import preponderous.viron.models.Location;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-@Slf4j
 public class LocationRepositoryImpl implements LocationRepository {
     private final DbInteractions dbInteractions;
 
@@ -29,81 +26,35 @@ public class LocationRepositoryImpl implements LocationRepository {
 
     @Override
     public List<Location> findAll() {
-        List<Location> locations = new ArrayList<>();
-        ResultSet rs = dbInteractions.query("SELECT * FROM viron.location");
-        if (rs == null) {
-            log.error("Error getting locations: ResultSet is null");
-            return locations;
-        }
-        try {
-            while (rs.next()) {
-                locations.add(mapResultSetToLocation(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting locations: {}", e.getMessage());
-        }
-        return locations;
+        return dbInteractions.query("SELECT * FROM viron.location", this::mapResultSetToLocation);
     }
 
     @Override
     public Optional<Location> findById(int id) {
-        ResultSet rs = dbInteractions.query("SELECT * FROM viron.location WHERE location_id = " + id);
-        try {
-            if (rs != null && rs.next()) {
-                return Optional.of(mapResultSetToLocation(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting location by id: {}", e.getMessage());
-        }
-        return Optional.empty();
+        return dbInteractions.queryOne("SELECT * FROM viron.location WHERE location_id = " + id,
+                this::mapResultSetToLocation);
     }
 
     @Override
     public List<Location> findByEnvironmentId(int environmentId) {
-        List<Location> locations = new ArrayList<>();
         String query = "SELECT * FROM viron.location WHERE location_id in " +
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
                 "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + "))";
-        ResultSet rs = dbInteractions.query(query);
-        try {
-            while (rs != null && rs.next()) {
-                locations.add(mapResultSetToLocation(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting locations in environment: {}", e.getMessage());
-        }
-        return locations;
+        return dbInteractions.query(query, this::mapResultSetToLocation);
     }
 
     @Override
     public List<Location> findByGridId(int gridId) {
-        List<Location> locations = new ArrayList<>();
         String query = "SELECT * FROM viron.location WHERE location_id in " +
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + ")";
-        ResultSet rs = dbInteractions.query(query);
-        try {
-            while (rs != null && rs.next()) {
-                locations.add(mapResultSetToLocation(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting locations in grid: {}", e.getMessage());
-        }
-        return locations;
+        return dbInteractions.query(query, this::mapResultSetToLocation);
     }
 
     @Override
     public Optional<Location> findByEntityId(int entityId) {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
                 "(SELECT location_id FROM viron.entity_location WHERE entity_id = " + entityId + ")";
-        ResultSet rs = dbInteractions.query(query);
-        try {
-            if (rs != null && rs.next()) {
-                return Optional.of(mapResultSetToLocation(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting location of entity: {}", e.getMessage());
-        }
-        return Optional.empty();
+        return dbInteractions.queryOne(query, this::mapResultSetToLocation);
     }
 
     @Override
@@ -128,48 +79,22 @@ public class LocationRepositoryImpl implements LocationRepository {
 
     @Override
     public List<Integer> getEntityIdsAtLocation(int locationId) {
-        List<Integer> entityIds = new ArrayList<>();
         String query = "SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId;
-        ResultSet rs = dbInteractions.query(query);
-        try {
-            while (rs != null && rs.next()) {
-                entityIds.add(rs.getInt("entity_id"));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting entities at location: {}", e.getMessage());
-        }
-        return entityIds;
+        return dbInteractions.query(query, rs -> rs.getInt("entity_id"));
     }
 
     @Override
     public List<Location> findUnoccupiedByGridId(int gridId) {
-        List<Location> locations = new ArrayList<>();
         String query = "SELECT * FROM viron.location WHERE location_id in " +
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + ") " +
                 "AND location_id not in (SELECT location_id FROM viron.entity_location)";
-        ResultSet rs = dbInteractions.query(query);
-        try {
-            while (rs != null && rs.next()) {
-                locations.add(mapResultSetToLocation(rs));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting unoccupied locations in grid: {}", e.getMessage());
-        }
-        return locations;
+        return dbInteractions.query(query, this::mapResultSetToLocation);
     }
 
     @Override
     public Optional<Integer> getGridIdOfLocation(int locationId) {
         String query = "SELECT grid_id FROM viron.location_grid WHERE location_id = " + locationId;
-        ResultSet rs = dbInteractions.query(query);
-        try {
-            if (rs != null && rs.next()) {
-                return Optional.of(rs.getInt("grid_id"));
-            }
-        } catch (SQLException e) {
-            log.error("Error getting grid of location: {}", e.getMessage());
-        }
-        return Optional.empty();
+        return dbInteractions.queryOne(query, rs -> rs.getInt("grid_id"));
     }
 
     @Override

--- a/src/test/java/preponderous/viron/database/DbInteractionsTest.java
+++ b/src/test/java/preponderous/viron/database/DbInteractionsTest.java
@@ -4,18 +4,27 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import preponderous.viron.config.DbConfig;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Exercises {@link DbInteractions} against an in-memory H2 database to verify
- * parameter binding (#139) and resource handling (#140). The application's real
- * SQL is Postgres-specific; this test uses its own neutral schema and only
- * validates the generic query/update mechanism.
+ * parameter binding (#139), resource handling (#140), and the row-mapping
+ * query API (#144). The application's real SQL is Postgres-specific; this test
+ * uses its own neutral schema and only validates the generic query/update
+ * mechanism.
  */
 public class DbInteractionsTest {
+
+    /** Row shape used by this test's neutral {@code person} schema. */
+    private record Person(int id, String name) {
+    }
+
+    private static final RowMapper<Person> PERSON_MAPPER =
+            rs -> new Person(rs.getInt("id"), rs.getString("name"));
 
     private DbInteractions dbInteractions;
 
@@ -32,53 +41,81 @@ public class DbInteractionsTest {
     }
 
     @Test
-    void update_bindsParameters_andQueryReturnsMatchingRow() throws SQLException {
+    void update_bindsParameters_andQueryOneReturnsMatchingRow() {
         boolean inserted = dbInteractions.update("INSERT INTO person (id, name) VALUES (?, ?)", 1, "Alice");
         assertThat(inserted).isTrue();
 
-        ResultSet rs = dbInteractions.query("SELECT id, name FROM person WHERE id = ?", 1);
+        Optional<Person> person =
+                dbInteractions.queryOne("SELECT id, name FROM person WHERE id = ?", PERSON_MAPPER, 1);
 
-        assertThat(rs).isNotNull();
-        assertThat(rs.next()).isTrue();
-        assertThat(rs.getInt("id")).isEqualTo(1);
-        assertThat(rs.getString("name")).isEqualTo("Alice");
-        assertThat(rs.next()).isFalse();
+        assertThat(person).contains(new Person(1, "Alice"));
     }
 
     // #139: a value containing a quote / SQL payload must be stored verbatim, never executed.
     @Test
-    void parameterizedValueWithSqlPayload_isStoredLiterally_andDoesNotInject() throws SQLException {
+    void parameterizedValueWithSqlPayload_isStoredLiterally_andDoesNotInject() {
         String tricky = "O'Brien'); DROP TABLE person; --";
 
         assertThat(dbInteractions.update("INSERT INTO person (id, name) VALUES (?, ?)", 2, tricky)).isTrue();
 
         // The table still exists (payload did not execute) and the value round-trips intact.
-        ResultSet rs = dbInteractions.query("SELECT name FROM person WHERE id = ?", 2);
-        assertThat(rs).isNotNull();
-        assertThat(rs.next()).isTrue();
-        assertThat(rs.getString("name")).isEqualTo(tricky);
+        Optional<Person> person =
+                dbInteractions.queryOne("SELECT id, name FROM person WHERE id = ?", PERSON_MAPPER, 2);
+        assertThat(person).isPresent();
+        assertThat(person.get().name()).isEqualTo(tricky);
     }
 
-    // #140: query() returns a disconnected result that stays readable after the method has
-    // returned and closed its PreparedStatement and live ResultSet internally.
+    // #140/#144: query() owns the cursor — callers only ever see mapped rows.
     @Test
-    void query_returnsDisconnectedResultSet_readableAfterReturn() throws SQLException {
+    void query_mapsEveryRow_inResultSetOrder() {
         dbInteractions.update("INSERT INTO person (id, name) VALUES (?, ?)", 3, "Carol");
         dbInteractions.update("INSERT INTO person (id, name) VALUES (?, ?)", 4, "Dave");
 
-        ResultSet rs = dbInteractions.query("SELECT id, name FROM person ORDER BY id");
+        List<Person> people = dbInteractions.query("SELECT id, name FROM person ORDER BY id", PERSON_MAPPER);
 
-        assertThat(rs).isNotNull();
-        int count = 0;
-        while (rs.next()) {
-            count++;
-        }
-        assertThat(count).isEqualTo(2);
+        assertThat(people).containsExactly(new Person(3, "Carol"), new Person(4, "Dave"));
     }
 
     @Test
-    void query_onInvalidSql_returnsNullAndDoesNotThrow() {
-        assertThat(dbInteractions.query("SELECT * FROM does_not_exist")).isNull();
+    void query_withNoMatchingRows_returnsEmptyList() {
+        assertThat(dbInteractions.query("SELECT id, name FROM person WHERE id = ?", PERSON_MAPPER, 999)).isEmpty();
+    }
+
+    @Test
+    void queryOne_withNoMatchingRows_returnsEmptyOptional() {
+        assertThat(dbInteractions.queryOne("SELECT id, name FROM person WHERE id = ?", PERSON_MAPPER, 999)).isEmpty();
+    }
+
+    @Test
+    void queryOne_withMultipleMatchingRows_returnsFirst() {
+        dbInteractions.update("INSERT INTO person (id, name) VALUES (?, ?)", 5, "Erin");
+        dbInteractions.update("INSERT INTO person (id, name) VALUES (?, ?)", 6, "Frank");
+
+        assertThat(dbInteractions.queryOne("SELECT id, name FROM person ORDER BY id", PERSON_MAPPER))
+                .contains(new Person(5, "Erin"));
+    }
+
+    @Test
+    void query_onInvalidSql_returnsEmptyListAndDoesNotThrow() {
+        assertThat(dbInteractions.query("SELECT * FROM does_not_exist", PERSON_MAPPER)).isEmpty();
+    }
+
+    @Test
+    void queryOne_onInvalidSql_returnsEmptyOptionalAndDoesNotThrow() {
+        assertThat(dbInteractions.queryOne("SELECT * FROM does_not_exist", PERSON_MAPPER)).isEmpty();
+    }
+
+    // A mapper that fails mid-iteration must not surface partially mapped rows.
+    @Test
+    void query_whenMapperThrows_returnsEmptyListAndDoesNotThrow() {
+        dbInteractions.update("INSERT INTO person (id, name) VALUES (?, ?)", 7, "Grace");
+
+        RowMapper<Person> failing = rs -> {
+            throw new SQLException("boom");
+        };
+
+        assertThat(dbInteractions.query("SELECT id, name FROM person", failing)).isEmpty();
+        assertThat(dbInteractions.queryOne("SELECT id, name FROM person", failing)).isEmpty();
     }
 
     @Test

--- a/src/test/java/preponderous/viron/database/ResultSetAnswers.java
+++ b/src/test/java/preponderous/viron/database/ResultSetAnswers.java
@@ -1,0 +1,47 @@
+package preponderous.viron.database;
+
+import org.mockito.stubbing.Answer;
+
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Mockito answers for stubbing {@link DbInteractions#query(String, RowMapper, Object...)} and
+ * {@link DbInteractions#queryOne(String, RowMapper, Object...)}.
+ *
+ * <p>Each answer drives the {@link RowMapper} the caller passed over a mocked {@link ResultSet},
+ * standing in for the iteration the real {@code DbInteractions} performs. That keeps a
+ * repository's row-mapping covered by its own tests even though the cursor itself is no longer
+ * visible to the repository.
+ *
+ * <p>Failure handling (a null cursor, a {@link java.sql.SQLException} mid-iteration) now lives in
+ * {@code DbInteractions} and is covered by {@code DbInteractionsTest} against H2; repositories
+ * only see the empty {@link List}/{@link Optional} that results, so stub those directly.
+ */
+public final class ResultSetAnswers {
+
+    private ResultSetAnswers() {
+    }
+
+    /** Maps every row of {@code rs}, as {@code DbInteractions.query} would. */
+    public static <T> Answer<List<T>> mapsAllRows(ResultSet rs) {
+        return invocation -> {
+            RowMapper<T> mapper = invocation.getArgument(1);
+            List<T> results = new ArrayList<>();
+            while (rs.next()) {
+                results.add(mapper.map(rs));
+            }
+            return results;
+        };
+    }
+
+    /** Maps the first row of {@code rs}, if any, as {@code DbInteractions.queryOne} would. */
+    public static <T> Answer<Optional<T>> mapsFirstRow(ResultSet rs) {
+        return invocation -> {
+            RowMapper<T> mapper = invocation.getArgument(1);
+            return rs.next() ? Optional.ofNullable(mapper.map(rs)) : Optional.empty();
+        };
+    }
+}

--- a/src/test/java/preponderous/viron/factories/EntityFactoryTest.java
+++ b/src/test/java/preponderous/viron/factories/EntityFactoryTest.java
@@ -8,13 +8,13 @@ import preponderous.viron.database.DbInteractions;
 import preponderous.viron.exceptions.EntityCreationException;
 import preponderous.viron.models.Entity;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -27,11 +27,8 @@ public class EntityFactoryTest {
     private DbInteractions dbInteractions;
 
     @Test
-    public void testCreateEntity_Success_ReturnsEntity() throws SQLException {
-        ResultSet idRs = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(NEXT_ID_QUERY)).thenReturn(idRs);
-        Mockito.when(idRs.next()).thenReturn(true);
-        Mockito.when(idRs.getInt(1)).thenReturn(5);
+    public void testCreateEntity_Success_ReturnsEntity() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ID_QUERY), any())).thenReturn(Optional.of(5));
         Mockito.when(dbInteractions.update(anyString(), any(), any())).thenReturn(true);
 
         EntityFactory factory = new EntityFactory(dbInteractions);
@@ -43,40 +40,23 @@ public class EntityFactoryTest {
         assertThat(result.getName()).isEqualTo("Bob");
     }
 
-    // #138 case 1: a null ResultSet from a failed nextval query must not NPE.
+    // #138: a nextval query that yields no id (failed query or no row) must not be inserted
+    // as a -1 sentinel. DbInteractions reports both cases as an empty Optional.
     @Test
-    public void testCreateEntity_NullResultSet_ThrowsAndDoesNotInsert() {
-        Mockito.when(dbInteractions.query(NEXT_ID_QUERY)).thenReturn(null);
+    public void testCreateEntity_NextIdUnavailable_ThrowsAndDoesNotInsert() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ID_QUERY), any())).thenReturn(Optional.empty());
 
         EntityFactory factory = new EntityFactory(dbInteractions);
 
         assertThatThrownBy(() -> factory.createEntity("Bob"))
                 .isInstanceOf(EntityCreationException.class)
                 .hasMessage("Failed to get next entity id");
-        verify(dbInteractions, never()).update(anyString());
-    }
-
-    // #138 case 2: a -1 sentinel id must not be inserted.
-    @Test
-    public void testCreateEntity_NextIdUnavailable_ThrowsAndDoesNotInsert() throws SQLException {
-        ResultSet idRs = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(NEXT_ID_QUERY)).thenReturn(idRs);
-        Mockito.when(idRs.next()).thenReturn(false); // no row -> getNextEntityId() returns -1
-
-        EntityFactory factory = new EntityFactory(dbInteractions);
-
-        assertThatThrownBy(() -> factory.createEntity("Bob"))
-                .isInstanceOf(EntityCreationException.class)
-                .hasMessage("Failed to get next entity id");
-        verify(dbInteractions, never()).update(anyString());
+        verify(dbInteractions, never()).update(anyString(), any(), any());
     }
 
     @Test
-    public void testCreateEntity_InsertFails_Throws() throws SQLException {
-        ResultSet idRs = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(NEXT_ID_QUERY)).thenReturn(idRs);
-        Mockito.when(idRs.next()).thenReturn(true);
-        Mockito.when(idRs.getInt(1)).thenReturn(5);
+    public void testCreateEntity_InsertFails_Throws() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ID_QUERY), any())).thenReturn(Optional.of(5));
         Mockito.when(dbInteractions.update(anyString(), any(), any())).thenReturn(false);
 
         EntityFactory factory = new EntityFactory(dbInteractions);

--- a/src/test/java/preponderous/viron/repositories/EntityRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/EntityRepositoryImplTest.java
@@ -9,10 +9,15 @@ import preponderous.viron.models.Entity;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static preponderous.viron.database.ResultSetAnswers.mapsAllRows;
+import static preponderous.viron.database.ResultSetAnswers.mapsFirstRow;
 
 @SpringBootTest
 public class EntityRepositoryImplTest {
@@ -25,7 +30,7 @@ public class EntityRepositoryImplTest {
         // Arrange
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
 
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity"), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false); // 2 entities in the result set
         Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(1, 2);
         Mockito.when(mockResultSet.getString("name")).thenReturn("Entity1", "Entity2");
@@ -51,7 +56,7 @@ public class EntityRepositoryImplTest {
         // Arrange
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
 
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity"), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false); // No entities in the result set
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -64,26 +69,9 @@ public class EntityRepositoryImplTest {
     }
 
     @Test
-    public void testFindAll_ReturnsEmptyListWhenResultSetIsNull() {
+    public void testFindAll_ReturnsEmptyListWhenQueryFails() {
         // Arrange
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity")).thenReturn(null); // ResultSet is null
-
-        EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
-
-        // Act
-        List<Entity> result = repository.findAll();
-
-        // Assert
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void testFindAll_HandlesSQLExceptionGracefully() throws SQLException {
-        // Arrange
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity")).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity"), any())).thenReturn(Collections.emptyList()); // ResultSet is null
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
 
@@ -100,7 +88,7 @@ public class EntityRepositoryImplTest {
         int entityId = 1;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
 
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id = " + entityId)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Entity>queryOne(eq("SELECT * FROM viron.entity WHERE entity_id = " + entityId), any())).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true); // Entity is found
         Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(entityId);
         Mockito.when(mockResultSet.getString("name")).thenReturn("Entity1");
@@ -124,7 +112,7 @@ public class EntityRepositoryImplTest {
         int entityId = 1;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
 
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id = " + entityId)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Entity>queryOne(eq("SELECT * FROM viron.entity WHERE entity_id = " + entityId), any())).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false); // Entity is not found
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -137,28 +125,10 @@ public class EntityRepositoryImplTest {
     }
 
     @Test
-    public void testFindById_ReturnsEmptyWhenResultSetIsNull() {
+    public void testFindById_ReturnsEmptyWhenQueryFails() {
         // Arrange
         int entityId = 1;
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id = " + entityId)).thenReturn(null); // ResultSet is null
-
-        EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
-
-        // Act
-        Optional<Entity> result = repository.findById(entityId);
-
-        // Assert
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void testFindById_HandlesSQLExceptionGracefully() throws SQLException {
-        // Arrange
-        int entityId = 1;
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id = " + entityId)).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
+        Mockito.when(dbInteractions.<Entity>queryOne(eq("SELECT * FROM viron.entity WHERE entity_id = " + entityId), any())).thenReturn(Optional.empty()); // ResultSet is null
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
 
@@ -174,11 +144,11 @@ public class EntityRepositoryImplTest {
         // Arrange
         int environmentId = 5;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id in " +
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
                         "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
                         "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
-                        "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))"))
-                .thenReturn(mockResultSet);
+                        "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))"), any()))
+                .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false); // 2 entities in the result set
         Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(1, 2);
         Mockito.when(mockResultSet.getString("name")).thenReturn("Entity1", "Entity2");
@@ -204,11 +174,11 @@ public class EntityRepositoryImplTest {
         // Arrange
         int environmentId = 5;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id in " +
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
                         "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
                         "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
-                        "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))"))
-                .thenReturn(mockResultSet);
+                        "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))"), any()))
+                .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false); // No entities in the result set
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -221,35 +191,14 @@ public class EntityRepositoryImplTest {
     }
 
     @Test
-    public void testFindByEnvironmentId_ReturnsEmptyListWhenResultSetIsNull() {
+    public void testFindByEnvironmentId_ReturnsEmptyListWhenQueryFails() {
         // Arrange
         int environmentId = 5;
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id in " +
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
                         "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
                         "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
-                        "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))"))
-                .thenReturn(null); // ResultSet is null
-
-        EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
-
-        // Act
-        List<Entity> result = repository.findByEnvironmentId(environmentId);
-
-        // Assert
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void testFindByEnvironmentId_HandlesSQLExceptionGracefully() throws SQLException {
-        // Arrange
-        int environmentId = 5;
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id in " +
-                        "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
-                        "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
-                        "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))"))
-                .thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
+                        "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))"), any()))
+                .thenReturn(Collections.emptyList()); // ResultSet is null
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
 
@@ -265,10 +214,10 @@ public class EntityRepositoryImplTest {
         // Arrange
         int gridId = 10;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id in " +
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
                         "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
-                        "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + "))"))
-                .thenReturn(mockResultSet);
+                        "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + "))"), any()))
+                .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false); // 2 entities in the result set
         Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(1, 2);
         Mockito.when(mockResultSet.getString("name")).thenReturn("Entity1", "Entity2");
@@ -294,10 +243,10 @@ public class EntityRepositoryImplTest {
         // Arrange
         int gridId = 10;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id in " +
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
                         "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
-                        "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + "))"))
-                .thenReturn(mockResultSet);
+                        "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + "))"), any()))
+                .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false); // No entities in the result set
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -310,33 +259,13 @@ public class EntityRepositoryImplTest {
     }
 
     @Test
-    public void testFindByGridId_ReturnsEmptyListWhenResultSetIsNull() {
+    public void testFindByGridId_ReturnsEmptyListWhenQueryFails() {
         // Arrange
         int gridId = 10;
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id in " +
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
                         "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
-                        "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + "))"))
-                .thenReturn(null); // ResultSet is null
-
-        EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
-
-        // Act
-        List<Entity> result = repository.findByGridId(gridId);
-
-        // Assert
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void testFindByGridId_HandlesSQLExceptionGracefully() throws SQLException {
-        // Arrange
-        int gridId = 10;
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id in " +
-                        "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
-                        "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + "))"))
-                .thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
+                        "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + "))"), any()))
+                .thenReturn(Collections.emptyList()); // ResultSet is null
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
 
@@ -352,9 +281,9 @@ public class EntityRepositoryImplTest {
         // Arrange
         int locationId = 15;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id in " +
-                        "(SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId + ")"))
-                .thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
+                        "(SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId + ")"), any()))
+                .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false); // 2 entities in the result set
         Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(1, 2);
         Mockito.when(mockResultSet.getString("name")).thenReturn("Entity1", "Entity2");
@@ -380,9 +309,9 @@ public class EntityRepositoryImplTest {
         // Arrange
         int locationId = 15;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id in " +
-                        "(SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId + ")"))
-                .thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
+                        "(SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId + ")"), any()))
+                .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false); // No entities in the result set
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -395,31 +324,12 @@ public class EntityRepositoryImplTest {
     }
 
     @Test
-    public void testFindByLocationId_ReturnsEmptyListWhenResultSetIsNull() {
+    public void testFindByLocationId_ReturnsEmptyListWhenQueryFails() {
         // Arrange
         int locationId = 15;
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id in " +
-                        "(SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId + ")"))
-                .thenReturn(null); // ResultSet is null
-
-        EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
-
-        // Act
-        List<Entity> result = repository.findByLocationId(locationId);
-
-        // Assert
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void testFindByLocationId_HandlesSQLExceptionGracefully() throws SQLException {
-        // Arrange
-        int locationId = 15;
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id in " +
-                        "(SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId + ")"))
-                .thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
+                        "(SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId + ")"), any()))
+                .thenReturn(Collections.emptyList()); // ResultSet is null
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
 
@@ -435,8 +345,8 @@ public class EntityRepositoryImplTest {
         // Arrange
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
 
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id not in (SELECT entity_id FROM viron.entity_location)"))
-                .thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id not in (SELECT entity_id FROM viron.entity_location)"), any()))
+                .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false); // 2 entities in the result set
         Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(1, 2);
         Mockito.when(mockResultSet.getString("name")).thenReturn("Entity1", "Entity2");
@@ -462,8 +372,8 @@ public class EntityRepositoryImplTest {
         // Arrange
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
 
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id not in (SELECT entity_id FROM viron.entity_location)"))
-                .thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id not in (SELECT entity_id FROM viron.entity_location)"), any()))
+                .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false); // No entities in the result set
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -476,28 +386,10 @@ public class EntityRepositoryImplTest {
     }
 
     @Test
-    public void testFindEntitiesNotInAnyLocation_ReturnsEmptyListWhenResultSetIsNull() {
+    public void testFindEntitiesNotInAnyLocation_ReturnsEmptyListWhenQueryFails() {
         // Arrange
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id not in (SELECT entity_id FROM viron.entity_location)"))
-                .thenReturn(null); // ResultSet is null
-
-        EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
-
-        // Act
-        List<Entity> result = repository.findEntitiesNotInAnyLocation();
-
-        // Assert
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void testFindEntitiesNotInAnyLocation_HandlesSQLExceptionGracefully() throws SQLException {
-        // Arrange
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id not in (SELECT entity_id FROM viron.entity_location)"))
-                .thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
+        Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id not in (SELECT entity_id FROM viron.entity_location)"), any()))
+                .thenReturn(Collections.emptyList()); // ResultSet is null
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
 
@@ -519,14 +411,15 @@ public class EntityRepositoryImplTest {
 
         // Mock getting the last inserted ID
         ResultSet idResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT LAST_INSERT_ID()")).thenReturn(idResultSet);
+        Mockito.when(dbInteractions.<Integer>queryOne(eq("SELECT LAST_INSERT_ID()"), any()))
+                .thenAnswer(mapsFirstRow(idResultSet));
         Mockito.when(idResultSet.next()).thenReturn(true);
         Mockito.when(idResultSet.getInt(1)).thenReturn(100);
 
         // Mock finding the entity by ID
         ResultSet entityResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.entity WHERE entity_id = 100"))
-                .thenReturn(entityResultSet);
+        Mockito.when(dbInteractions.<Entity>queryOne(eq("SELECT * FROM viron.entity WHERE entity_id = 100"), any()))
+                .thenAnswer(mapsFirstRow(entityResultSet));
         Mockito.when(entityResultSet.next()).thenReturn(true);
         Mockito.when(entityResultSet.getInt("entity_id")).thenReturn(100);
         Mockito.when(entityResultSet.getString("name")).thenReturn("Entity1");

--- a/src/test/java/preponderous/viron/repositories/EnvironmentRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/EnvironmentRepositoryImplTest.java
@@ -9,10 +9,15 @@ import preponderous.viron.models.Environment;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static preponderous.viron.database.ResultSetAnswers.mapsAllRows;
+import static preponderous.viron.database.ResultSetAnswers.mapsFirstRow;
 
 @SpringBootTest
 public class EnvironmentRepositoryImplTest {
@@ -25,7 +30,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindAll_ReturnsEnvironmentsWhenResultSetIsNotEmpty() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Environment>query(eq("SELECT * FROM viron.environment"), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false);
         Mockito.when(mockResultSet.getInt("environment_id")).thenReturn(1, 2);
         Mockito.when(mockResultSet.getString("name")).thenReturn("Env1", "Env2");
@@ -47,7 +52,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindAll_ReturnsEmptyListWhenResultSetIsEmpty() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Environment>query(eq("SELECT * FROM viron.environment"), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -58,21 +63,8 @@ public class EnvironmentRepositoryImplTest {
     }
 
     @Test
-    public void testFindAll_ReturnsEmptyListWhenSQLExceptionThrown() throws SQLException {
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment")).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
-
-        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
-
-        List<Environment> result = repository.findAll();
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void testFindAll_ReturnsEmptyListWhenResultSetIsNull() {
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment")).thenReturn(null);
+    public void testFindAll_ReturnsEmptyListWhenQueryFails() {
+        Mockito.when(dbInteractions.<Environment>query(eq("SELECT * FROM viron.environment"), any())).thenReturn(Collections.emptyList());
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -87,7 +79,7 @@ public class EnvironmentRepositoryImplTest {
     public void testFindById_ReturnsEnvironmentWhenRowExists() throws SQLException {
         int id = 1;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = " + id)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = " + id), any())).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("environment_id")).thenReturn(id);
         Mockito.when(mockResultSet.getString("name")).thenReturn("Env1");
@@ -107,7 +99,7 @@ public class EnvironmentRepositoryImplTest {
     public void testFindById_ReturnsEmptyWhenNoRow() throws SQLException {
         int id = 1;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = " + id)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = " + id), any())).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -118,23 +110,9 @@ public class EnvironmentRepositoryImplTest {
     }
 
     @Test
-    public void testFindById_ReturnsEmptyWhenSQLExceptionThrown() throws SQLException {
+    public void testFindById_ReturnsEmptyWhenQueryFails() {
         int id = 1;
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = " + id)).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
-
-        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
-
-        Optional<Environment> result = repository.findById(id);
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void testFindById_ReturnsEmptyWhenResultSetIsNull() {
-        int id = 1;
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = " + id)).thenReturn(null);
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = " + id), any())).thenReturn(Optional.empty());
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -149,7 +127,7 @@ public class EnvironmentRepositoryImplTest {
     public void testFindByName_ReturnsEnvironmentWhenRowExists() throws SQLException {
         String name = "Env1";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE name = ?", name)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE name = ?"), any(), eq(name))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("environment_id")).thenReturn(1);
         Mockito.when(mockResultSet.getString("name")).thenReturn(name);
@@ -169,7 +147,7 @@ public class EnvironmentRepositoryImplTest {
     public void testFindByName_ReturnsEmptyWhenNoRow() throws SQLException {
         String name = "Env1";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE name = ?", name)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE name = ?"), any(), eq(name))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -180,23 +158,9 @@ public class EnvironmentRepositoryImplTest {
     }
 
     @Test
-    public void testFindByName_ReturnsEmptyWhenSQLExceptionThrown() throws SQLException {
+    public void testFindByName_ReturnsEmptyWhenQueryFails() {
         String name = "Env1";
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE name = ?", name)).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
-
-        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
-
-        Optional<Environment> result = repository.findByName(name);
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void testFindByName_ReturnsEmptyWhenResultSetIsNull() {
-        String name = "Env1";
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE name = ?", name)).thenReturn(null);
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE name = ?"), any(), eq(name))).thenReturn(Optional.empty());
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -211,7 +175,7 @@ public class EnvironmentRepositoryImplTest {
     public void testFindByEntityId_ReturnsEnvironmentWhenRowExists() throws SQLException {
         int entityId = 7;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")"), any())).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("environment_id")).thenReturn(3);
         Mockito.when(mockResultSet.getString("name")).thenReturn("Env3");
@@ -231,7 +195,7 @@ public class EnvironmentRepositoryImplTest {
     public void testFindByEntityId_ReturnsEmptyWhenNoRow() throws SQLException {
         int entityId = 7;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")"), any())).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -242,23 +206,9 @@ public class EnvironmentRepositoryImplTest {
     }
 
     @Test
-    public void testFindByEntityId_ReturnsEmptyWhenSQLExceptionThrown() throws SQLException {
+    public void testFindByEntityId_ReturnsEmptyWhenQueryFails() {
         int entityId = 7;
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")")).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
-
-        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
-
-        Optional<Environment> result = repository.findByEntityId(entityId);
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void testFindByEntityId_ReturnsEmptyWhenResultSetIsNull() {
-        int entityId = 7;
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")")).thenReturn(null);
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")"), any())).thenReturn(Optional.empty());
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -334,7 +284,7 @@ public class EnvironmentRepositoryImplTest {
         int environmentId = 5;
         String query = "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false);
         Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(11, 22);
 
@@ -350,7 +300,7 @@ public class EnvironmentRepositoryImplTest {
         int environmentId = 5;
         String query = "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -361,25 +311,10 @@ public class EnvironmentRepositoryImplTest {
     }
 
     @Test
-    public void testFindEntityIdsByEnvironmentId_ReturnsEmptyListWhenSQLExceptionThrown() throws SQLException {
+    public void testFindEntityIdsByEnvironmentId_ReturnsEmptyListWhenQueryFails() {
         int environmentId = 5;
         String query = "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))";
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
-
-        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
-
-        List<Integer> result = repository.findEntityIdsByEnvironmentId(environmentId);
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void testFindEntityIdsByEnvironmentId_ReturnsEmptyListWhenResultSetIsNull() {
-        int environmentId = 5;
-        String query = "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))";
-        Mockito.when(dbInteractions.query(query)).thenReturn(null);
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenReturn(Collections.emptyList());
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -395,7 +330,7 @@ public class EnvironmentRepositoryImplTest {
         int environmentId = 5;
         String query = "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false);
         Mockito.when(mockResultSet.getInt("location_id")).thenReturn(33, 44);
 
@@ -411,7 +346,7 @@ public class EnvironmentRepositoryImplTest {
         int environmentId = 5;
         String query = "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -422,25 +357,10 @@ public class EnvironmentRepositoryImplTest {
     }
 
     @Test
-    public void testFindLocationIdsByEnvironmentId_ReturnsEmptyListWhenSQLExceptionThrown() throws SQLException {
+    public void testFindLocationIdsByEnvironmentId_ReturnsEmptyListWhenQueryFails() {
         int environmentId = 5;
         String query = "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")";
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
-
-        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
-
-        List<Integer> result = repository.findLocationIdsByEnvironmentId(environmentId);
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void testFindLocationIdsByEnvironmentId_ReturnsEmptyListWhenResultSetIsNull() {
-        int environmentId = 5;
-        String query = "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")";
-        Mockito.when(dbInteractions.query(query)).thenReturn(null);
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenReturn(Collections.emptyList());
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -456,7 +376,7 @@ public class EnvironmentRepositoryImplTest {
         int environmentId = 5;
         String query = "SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false);
         Mockito.when(mockResultSet.getInt("grid_id")).thenReturn(55, 66);
 
@@ -472,7 +392,7 @@ public class EnvironmentRepositoryImplTest {
         int environmentId = 5;
         String query = "SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -483,25 +403,10 @@ public class EnvironmentRepositoryImplTest {
     }
 
     @Test
-    public void testFindGridIdsByEnvironmentId_ReturnsEmptyListWhenSQLExceptionThrown() throws SQLException {
+    public void testFindGridIdsByEnvironmentId_ReturnsEmptyListWhenQueryFails() {
         int environmentId = 5;
         String query = "SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId;
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("Simulated SQL Exception"));
-
-        EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
-
-        List<Integer> result = repository.findGridIdsByEnvironmentId(environmentId);
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void testFindGridIdsByEnvironmentId_ReturnsEmptyListWhenResultSetIsNull() {
-        int environmentId = 5;
-        String query = "SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId;
-        Mockito.when(dbInteractions.query(query)).thenReturn(null);
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenReturn(Collections.emptyList());
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 

--- a/src/test/java/preponderous/viron/repositories/GridRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/GridRepositoryImplTest.java
@@ -9,10 +9,15 @@ import preponderous.viron.models.Grid;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static preponderous.viron.database.ResultSetAnswers.mapsAllRows;
+import static preponderous.viron.database.ResultSetAnswers.mapsFirstRow;
 
 @SpringBootTest
 public class GridRepositoryImplTest {
@@ -25,7 +30,7 @@ public class GridRepositoryImplTest {
     @Test
     public void testFindAll_ReturnsGridsWhenResultSetIsNotEmpty() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.grid")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Grid>query(eq("SELECT * FROM viron.grid"), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false);
         Mockito.when(mockResultSet.getInt("grid_id")).thenReturn(1, 2);
         Mockito.when(mockResultSet.getInt("rows")).thenReturn(10, 20);
@@ -47,7 +52,7 @@ public class GridRepositoryImplTest {
     @Test
     public void testFindAll_ReturnsEmptyListWhenResultSetIsEmpty() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.grid")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Grid>query(eq("SELECT * FROM viron.grid"), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
@@ -56,19 +61,8 @@ public class GridRepositoryImplTest {
     }
 
     @Test
-    public void testFindAll_ReturnsEmptyListWhenResultSetIsNull() {
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.grid")).thenReturn(null);
-
-        GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
-
-        assertThat(repository.findAll()).isEmpty();
-    }
-
-    @Test
-    public void testFindAll_ReturnsEmptyListWhenSQLExceptionThrown() throws SQLException {
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.grid")).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("boom"));
+    public void testFindAll_ReturnsEmptyListWhenQueryFails() {
+        Mockito.when(dbInteractions.<Grid>query(eq("SELECT * FROM viron.grid"), any())).thenReturn(Collections.emptyList());
 
         GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
 
@@ -80,7 +74,7 @@ public class GridRepositoryImplTest {
     @Test
     public void testFindById_ReturnsGridWhenRowExists() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.grid WHERE grid_id = 1")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Grid>queryOne(eq("SELECT * FROM viron.grid WHERE grid_id = 1"), any())).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("grid_id")).thenReturn(1);
         Mockito.when(mockResultSet.getInt("rows")).thenReturn(10);
@@ -99,7 +93,7 @@ public class GridRepositoryImplTest {
     @Test
     public void testFindById_ReturnsEmptyWhenNoRow() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.grid WHERE grid_id = 99")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Grid>queryOne(eq("SELECT * FROM viron.grid WHERE grid_id = 99"), any())).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
@@ -108,19 +102,8 @@ public class GridRepositoryImplTest {
     }
 
     @Test
-    public void testFindById_ReturnsEmptyWhenResultSetIsNull() {
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.grid WHERE grid_id = 1")).thenReturn(null);
-
-        GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
-
-        assertThat(repository.findById(1)).isEmpty();
-    }
-
-    @Test
-    public void testFindById_ReturnsEmptyWhenSQLExceptionThrown() throws SQLException {
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.grid WHERE grid_id = 1")).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("boom"));
+    public void testFindById_ReturnsEmptyWhenQueryFails() {
+        Mockito.when(dbInteractions.<Grid>queryOne(eq("SELECT * FROM viron.grid WHERE grid_id = 1"), any())).thenReturn(Optional.empty());
 
         GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
 
@@ -134,7 +117,7 @@ public class GridRepositoryImplTest {
         String query = "SELECT * FROM viron.grid WHERE grid_id in " +
                 "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = 7)";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Grid>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, false);
         Mockito.when(mockResultSet.getInt("grid_id")).thenReturn(3);
         Mockito.when(mockResultSet.getInt("rows")).thenReturn(8);
@@ -149,10 +132,10 @@ public class GridRepositoryImplTest {
     }
 
     @Test
-    public void testFindByEnvironmentId_ReturnsEmptyListWhenResultSetIsNull() {
+    public void testFindByEnvironmentId_ReturnsEmptyListWhenQueryFails() {
         String query = "SELECT * FROM viron.grid WHERE grid_id in " +
                 "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = 7)";
-        Mockito.when(dbInteractions.query(query)).thenReturn(null);
+        Mockito.when(dbInteractions.<Grid>query(eq(query), any())).thenReturn(Collections.emptyList());
 
         GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
 
@@ -167,7 +150,7 @@ public class GridRepositoryImplTest {
                 "(SELECT grid_id FROM viron.location_grid WHERE location_id in " +
                 "(SELECT location_id FROM viron.entity_location WHERE entity_id = 42))";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Grid>queryOne(eq(query), any())).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("grid_id")).thenReturn(9);
         Mockito.when(mockResultSet.getInt("rows")).thenReturn(4);
@@ -182,11 +165,11 @@ public class GridRepositoryImplTest {
     }
 
     @Test
-    public void testFindByEntityId_ReturnsEmptyWhenResultSetIsNull() {
+    public void testFindByEntityId_ReturnsEmptyWhenQueryFails() {
         String query = "SELECT * FROM viron.grid WHERE grid_id in " +
                 "(SELECT grid_id FROM viron.location_grid WHERE location_id in " +
                 "(SELECT location_id FROM viron.entity_location WHERE entity_id = 42))";
-        Mockito.when(dbInteractions.query(query)).thenReturn(null);
+        Mockito.when(dbInteractions.<Grid>queryOne(eq(query), any())).thenReturn(Optional.empty());
 
         GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
 

--- a/src/test/java/preponderous/viron/repositories/LocationRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/LocationRepositoryImplTest.java
@@ -9,10 +9,15 @@ import preponderous.viron.models.Location;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static preponderous.viron.database.ResultSetAnswers.mapsAllRows;
+import static preponderous.viron.database.ResultSetAnswers.mapsFirstRow;
 
 @SpringBootTest
 public class LocationRepositoryImplTest {
@@ -25,7 +30,7 @@ public class LocationRepositoryImplTest {
     @Test
     public void testFindAll_ReturnsLocationsWhenResultSetIsNotEmpty() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.location")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Location>query(eq("SELECT * FROM viron.location"), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false);
         Mockito.when(mockResultSet.getInt("location_id")).thenReturn(1, 2);
         Mockito.when(mockResultSet.getInt("x")).thenReturn(3, 7);
@@ -47,7 +52,7 @@ public class LocationRepositoryImplTest {
     @Test
     public void testFindAll_ReturnsEmptyListWhenResultSetIsEmpty() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.location")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Location>query(eq("SELECT * FROM viron.location"), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
@@ -56,19 +61,8 @@ public class LocationRepositoryImplTest {
     }
 
     @Test
-    public void testFindAll_ReturnsEmptyListWhenResultSetIsNull() {
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.location")).thenReturn(null);
-
-        LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
-
-        assertThat(repository.findAll()).isEmpty();
-    }
-
-    @Test
-    public void testFindAll_ReturnsEmptyListWhenSQLExceptionThrown() throws SQLException {
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.location")).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenThrow(new SQLException("boom"));
+    public void testFindAll_ReturnsEmptyListWhenQueryFails() {
+        Mockito.when(dbInteractions.<Location>query(eq("SELECT * FROM viron.location"), any())).thenReturn(Collections.emptyList());
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -80,7 +74,7 @@ public class LocationRepositoryImplTest {
     @Test
     public void testFindById_ReturnsLocationWhenRowExists() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.location WHERE location_id = 1")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Location>queryOne(eq("SELECT * FROM viron.location WHERE location_id = 1"), any())).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("location_id")).thenReturn(1);
         Mockito.when(mockResultSet.getInt("x")).thenReturn(3);
@@ -99,7 +93,7 @@ public class LocationRepositoryImplTest {
     @Test
     public void testFindById_ReturnsEmptyWhenNoRow() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.location WHERE location_id = 99")).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Location>queryOne(eq("SELECT * FROM viron.location WHERE location_id = 99"), any())).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
@@ -108,8 +102,8 @@ public class LocationRepositoryImplTest {
     }
 
     @Test
-    public void testFindById_ReturnsEmptyWhenResultSetIsNull() {
-        Mockito.when(dbInteractions.query("SELECT * FROM viron.location WHERE location_id = 1")).thenReturn(null);
+    public void testFindById_ReturnsEmptyWhenQueryFails() {
+        Mockito.when(dbInteractions.<Location>queryOne(eq("SELECT * FROM viron.location WHERE location_id = 1"), any())).thenReturn(Optional.empty());
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -124,7 +118,7 @@ public class LocationRepositoryImplTest {
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
                 "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = 7))";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Location>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, false);
         Mockito.when(mockResultSet.getInt("location_id")).thenReturn(5);
         Mockito.when(mockResultSet.getInt("x")).thenReturn(1);
@@ -139,11 +133,11 @@ public class LocationRepositoryImplTest {
     }
 
     @Test
-    public void testFindByEnvironmentId_ReturnsEmptyListWhenResultSetIsNull() {
+    public void testFindByEnvironmentId_ReturnsEmptyListWhenQueryFails() {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
                 "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = 7))";
-        Mockito.when(dbInteractions.query(query)).thenReturn(null);
+        Mockito.when(dbInteractions.<Location>query(eq(query), any())).thenReturn(Collections.emptyList());
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -157,7 +151,7 @@ public class LocationRepositoryImplTest {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id = 3)";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Location>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false);
         Mockito.when(mockResultSet.getInt("location_id")).thenReturn(5, 6);
         Mockito.when(mockResultSet.getInt("x")).thenReturn(1, 2);
@@ -173,10 +167,10 @@ public class LocationRepositoryImplTest {
     }
 
     @Test
-    public void testFindByGridId_ReturnsEmptyListWhenResultSetIsNull() {
+    public void testFindByGridId_ReturnsEmptyListWhenQueryFails() {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id = 3)";
-        Mockito.when(dbInteractions.query(query)).thenReturn(null);
+        Mockito.when(dbInteractions.<Location>query(eq(query), any())).thenReturn(Collections.emptyList());
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -191,7 +185,7 @@ public class LocationRepositoryImplTest {
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id = 3) " +
                 "AND location_id not in (SELECT location_id FROM viron.entity_location)";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Location>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false);
         Mockito.when(mockResultSet.getInt("location_id")).thenReturn(5, 6);
         Mockito.when(mockResultSet.getInt("x")).thenReturn(1, 2);
@@ -207,11 +201,11 @@ public class LocationRepositoryImplTest {
     }
 
     @Test
-    public void testFindUnoccupiedByGridId_ReturnsEmptyListWhenResultSetIsNull() {
+    public void testFindUnoccupiedByGridId_ReturnsEmptyListWhenQueryFails() {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id = 3) " +
                 "AND location_id not in (SELECT location_id FROM viron.entity_location)";
-        Mockito.when(dbInteractions.query(query)).thenReturn(null);
+        Mockito.when(dbInteractions.<Location>query(eq(query), any())).thenReturn(Collections.emptyList());
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -225,7 +219,7 @@ public class LocationRepositoryImplTest {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
                 "(SELECT location_id FROM viron.entity_location WHERE entity_id = 42)";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(query)).thenReturn(mockResultSet);
+        Mockito.when(dbInteractions.<Location>queryOne(eq(query), any())).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("location_id")).thenReturn(8);
         Mockito.when(mockResultSet.getInt("x")).thenReturn(0);
@@ -240,10 +234,10 @@ public class LocationRepositoryImplTest {
     }
 
     @Test
-    public void testFindByEntityId_ReturnsEmptyWhenResultSetIsNull() {
+    public void testFindByEntityId_ReturnsEmptyWhenQueryFails() {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
                 "(SELECT location_id FROM viron.entity_location WHERE entity_id = 42)";
-        Mockito.when(dbInteractions.query(query)).thenReturn(null);
+        Mockito.when(dbInteractions.<Location>queryOne(eq(query), any())).thenReturn(Optional.empty());
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -300,8 +294,8 @@ public class LocationRepositoryImplTest {
     @Test
     public void testGetEntityIdsAtLocation_ReturnsIdsWhenResultSetNotEmpty() throws SQLException {
         ResultSet rs = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT entity_id FROM viron.entity_location WHERE location_id = 7"))
-                .thenReturn(rs);
+        Mockito.when(dbInteractions.<Integer>query(eq("SELECT entity_id FROM viron.entity_location WHERE location_id = 7"), any()))
+                .thenAnswer(mapsAllRows(rs));
         Mockito.when(rs.next()).thenReturn(true, true, false);
         Mockito.when(rs.getInt("entity_id")).thenReturn(11, 22);
 
@@ -311,8 +305,8 @@ public class LocationRepositoryImplTest {
     }
 
     @Test
-    public void testGetEntityIdsAtLocation_ReturnsEmptyWhenResultSetNull() {
-        Mockito.when(dbInteractions.query(Mockito.anyString())).thenReturn(null);
+    public void testGetEntityIdsAtLocation_ReturnsEmptyWhenQueryFails() {
+        Mockito.when(dbInteractions.<Integer>query(Mockito.anyString(), any())).thenReturn(Collections.emptyList());
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -324,8 +318,8 @@ public class LocationRepositoryImplTest {
     @Test
     public void testGetGridIdOfLocation_ReturnsGridWhenPresent() throws SQLException {
         ResultSet rs = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query("SELECT grid_id FROM viron.location_grid WHERE location_id = 5"))
-                .thenReturn(rs);
+        Mockito.when(dbInteractions.<Integer>queryOne(eq("SELECT grid_id FROM viron.location_grid WHERE location_id = 5"), any()))
+                .thenAnswer(mapsFirstRow(rs));
         Mockito.when(rs.next()).thenReturn(true);
         Mockito.when(rs.getInt("grid_id")).thenReturn(3);
 
@@ -337,7 +331,7 @@ public class LocationRepositoryImplTest {
     @Test
     public void testGetGridIdOfLocation_EmptyWhenNoRow() throws SQLException {
         ResultSet rs = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.query(Mockito.anyString())).thenReturn(rs);
+        Mockito.when(dbInteractions.<Integer>queryOne(Mockito.anyString(), any())).thenAnswer(mapsFirstRow(rs));
         Mockito.when(rs.next()).thenReturn(false);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);


### PR DESCRIPTION
## Summary

`DbInteractions.query(...)` returned a raw (disconnected) `ResultSet`, so every repository re-implemented the same iterate-map-and-error-handle boilerplate: a `null` guard, a `while (rs.next())` loop, and a `catch (SQLException)` swallow — repeated across ~18 query methods in the four repositories plus four id-sequence lookups in the factories.

- Add `database/RowMapper.java`, a `@FunctionalInterface` mapping the row a `ResultSet` is currently positioned on.
- Replace `ResultSet query(String, Object...)` with:
  - `<T> List<T> query(String, RowMapper<T>, Object...)`
  - `<T> Optional<T> queryOne(String, RowMapper<T>, Object...)`

  Both own the `PreparedStatement`/`ResultSet`, iterate internally, and return an empty `List`/`Optional` on error. The `CachedRowSet` machinery added for #140 is no longer needed, since nothing escapes the method.
- Migrate all 30 call sites across `EnvironmentRepositoryImpl`, `EntityRepositoryImpl`, `GridRepositoryImpl`, `LocationRepositoryImpl`, `EntityFactory`, and `EnvironmentFactory`. Each query method is now a single expression passing its existing `mapResultSetTo*` helper as a method reference.
- Drop `@Slf4j` from the three repositories whose only logging was the removed error boilerplate.

Because no caller can hold a `ResultSet` any more, the missing-`null`-guard bug this codebase hit twice (#132, #138) is now unrepresentable rather than merely fixed.

No SQL string, endpoint, request/response shape, or DB schema changed — this is internal to the data layer, so the OpenAPI spec and the Python SDK are unaffected.

## Test plan

- [x] Repository tests migrated to the new API via a new test helper, `ResultSetAnswers`, whose Mockito answers drive the `RowMapper` the repository passed over a mocked `ResultSet`. This keeps each repository's row mapping covered by its own tests even though the cursor is no longer visible to the repository.
- [x] Per-repository `ResultSet is null` / `SQLException thrown` cases collapse into one `...WhenQueryFails` case each, since that handling now lives in one place. The underlying behaviour is covered directly in `DbInteractionsTest` against H2, which gains cases for: `query`/`queryOne` on invalid SQL, no matching rows, multiple matching rows, and a `RowMapper` that throws mid-iteration.
- [x] `EntityFactoryTest`'s two #138 regression cases (null cursor, no row) become the single empty-`Optional` case they now both produce.
- [ ] `./mvnw test -B` — **not runnable in this environment** (no Maven access); relying on the CI workflow's `./mvnw compile -B` + `./mvnw test -B` on this branch as the authoritative signal.
- [x] `pytest` — not applicable, no Python SDK changes.

Closes #144

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
