### PR TITLE
refactor: bind remaining int SQL parameters instead of interpolating them

### DIFF
--- a/src/main/java/preponderous/viron/factories/EntityFactory.java
+++ b/src/main/java/preponderous/viron/factories/EntityFactory.java
@@ -28,8 +28,8 @@ public class EntityFactory {
             throw new EntityCreationException("Failed to get next entity id");
         }
         String creationDate = new java.util.Date().toString();
-        String query = "INSERT INTO viron.entity (entity_id, name, creation_date) VALUES (" + id + ", ?, ?)";
-        boolean success = dbInteractions.update(query, name, creationDate);
+        String query = "INSERT INTO viron.entity (entity_id, name, creation_date) VALUES (?, ?, ?)";
+        boolean success = dbInteractions.update(query, id, name, creationDate);
         if (success) {
             log.info("Successfully created entity with name: {} and id: {} and creation date: {}", name, id, creationDate);
             return new Entity(id, name, creationDate);

--- a/src/main/java/preponderous/viron/factories/EnvironmentFactory.java
+++ b/src/main/java/preponderous/viron/factories/EnvironmentFactory.java
@@ -41,8 +41,8 @@ public class EnvironmentFactory {
             throw new EnvironmentCreationException("Failed to get next environment id");
         }
         String creationDate = new java.util.Date().toString();
-        String query = "INSERT INTO viron.environment (environment_id, name, creation_date) VALUES (" + id + ", ?, ?)";
-        boolean success = dbInteractions.update(query, name, creationDate);
+        String query = "INSERT INTO viron.environment (environment_id, name, creation_date) VALUES (?, ?, ?)";
+        boolean success = dbInteractions.update(query, id, name, creationDate);
         if (!success) {
             log.error("Failed to create environment");
             throw new EnvironmentCreationException("Failed to create environment");
@@ -66,8 +66,8 @@ public class EnvironmentFactory {
             }
 
             // associate grid with environment
-            query = "INSERT INTO viron.grid_environment (grid_id, environment_id) VALUES (" + nextGridId + ", " + id + ")";
-            success = dbInteractions.update(query);
+            query = "INSERT INTO viron.grid_environment (grid_id, environment_id) VALUES (?, ?)";
+            success = dbInteractions.update(query, nextGridId, id);
             if (!success) {
                 log.error("Failed to associate grid with environment");
                 throw new EnvironmentCreationException("Failed to associate grid with environment");
@@ -82,16 +82,16 @@ public class EnvironmentFactory {
                         log.error("Failed to get next location id");
                         throw new EnvironmentCreationException("Failed to get next location id");
                     }
-                    query = "INSERT INTO viron.location (location_id, x, y) VALUES (" + locationId + ", " + x + ", " + y + ")";
-                    success = dbInteractions.update(query);
+                    query = "INSERT INTO viron.location (location_id, x, y) VALUES (?, ?, ?)";
+                    success = dbInteractions.update(query, locationId, x, y);
                     if (!success) {
                         log.error("Failed to create location");
                         throw new EnvironmentCreationException("Failed to create location");
                     }
 
                     // associate location with grid
-                    query = "INSERT INTO viron.location_grid (location_id, grid_id) VALUES (" + locationId + ", " + nextGridId + ")";
-                    success = dbInteractions.update(query);
+                    query = "INSERT INTO viron.location_grid (location_id, grid_id) VALUES (?, ?)";
+                    success = dbInteractions.update(query, locationId, nextGridId);
                     if (!success) {
                         log.error("Failed to associate location with grid");
                         throw new EnvironmentCreationException("Failed to associate location with grid");

--- a/src/main/java/preponderous/viron/repositories/EntityRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/EntityRepositoryImpl.java
@@ -31,8 +31,8 @@ public class EntityRepositoryImpl implements EntityRepository {
 
     @Override
     public Optional<Entity> findById(int id) {
-        return dbInteractions.queryOne("SELECT * FROM viron.entity WHERE entity_id = " + id,
-                this::mapResultSetToEntity);
+        return dbInteractions.queryOne("SELECT * FROM viron.entity WHERE entity_id = ?",
+                this::mapResultSetToEntity, id);
     }
 
     @Override
@@ -40,26 +40,26 @@ public class EntityRepositoryImpl implements EntityRepository {
         String query = "SELECT * FROM viron.entity WHERE entity_id in " +
                 "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
-                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))";
+                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)))";
 
-        return dbInteractions.query(query, this::mapResultSetToEntity);
+        return dbInteractions.query(query, this::mapResultSetToEntity, environmentId);
     }
 
     @Override
     public List<Entity> findByGridId(int gridId) {
         String query = "SELECT * FROM viron.entity WHERE entity_id in " +
                 "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
-                "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + "))";
+                "(SELECT location_id FROM viron.location_grid WHERE grid_id = ?))";
 
-        return dbInteractions.query(query, this::mapResultSetToEntity);
+        return dbInteractions.query(query, this::mapResultSetToEntity, gridId);
     }
 
     @Override
     public List<Entity> findByLocationId(int locationId) {
         String query = "SELECT * FROM viron.entity WHERE entity_id in " +
-                "(SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId + ")";
+                "(SELECT entity_id FROM viron.entity_location WHERE location_id = ?)";
 
-        return dbInteractions.query(query, this::mapResultSetToEntity);
+        return dbInteractions.query(query, this::mapResultSetToEntity, locationId);
     }
 
     @Override
@@ -86,13 +86,13 @@ public class EntityRepositoryImpl implements EntityRepository {
 
     @Override
     public boolean deleteById(int id) {
-        String query = "DELETE FROM viron.entity WHERE entity_id = " + id;
-        return dbInteractions.update(query);
+        String query = "DELETE FROM viron.entity WHERE entity_id = ?";
+        return dbInteractions.update(query, id);
     }
 
     @Override
     public boolean updateName(int id, String name) {
-        String query = "UPDATE viron.entity SET name = ? WHERE entity_id = " + id;
-        return dbInteractions.update(query, name);
+        String query = "UPDATE viron.entity SET name = ? WHERE entity_id = ?";
+        return dbInteractions.update(query, name, id);
     }
 }

--- a/src/main/java/preponderous/viron/repositories/EnvironmentRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/EnvironmentRepositoryImpl.java
@@ -26,8 +26,8 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
 
     @Override
     public Optional<Environment> findById(int id) {
-        return dbInteractions.queryOne("SELECT * FROM viron.environment WHERE environment_id = " + id,
-                this::mapResultSetToEnvironment);
+        return dbInteractions.queryOne("SELECT * FROM viron.environment WHERE environment_id = ?",
+                this::mapResultSetToEnvironment, id);
     }
 
     @Override
@@ -39,8 +39,8 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
     @Override
     public Optional<Environment> findByEntityId(int entityId) {
         return dbInteractions.queryOne(
-                "SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")",
-                this::mapResultSetToEnvironment);
+                "SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = ?)",
+                this::mapResultSetToEnvironment, entityId);
     }
 
     @Override
@@ -50,65 +50,65 @@ public class EnvironmentRepositoryImpl implements EnvironmentRepository {
 
     @Override
     public boolean deleteById(int id) {
-        String query = "DELETE FROM viron.environment WHERE environment_id = " + id;
-        return dbInteractions.update(query);
+        String query = "DELETE FROM viron.environment WHERE environment_id = ?";
+        return dbInteractions.update(query, id);
     }
 
     @Override
     public boolean updateName(int id, String name) {
-        String query = "UPDATE viron.environment SET name = ? WHERE environment_id = " + id;
-        return dbInteractions.update(query, name);
+        String query = "UPDATE viron.environment SET name = ? WHERE environment_id = ?";
+        return dbInteractions.update(query, name, id);
     }
 
     @Override
     public List<Integer> findEntityIdsByEnvironmentId(int environmentId) {
         return dbInteractions.query(
-                "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))",
-                rs -> rs.getInt("entity_id"));
+                "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)))",
+                rs -> rs.getInt("entity_id"), environmentId);
     }
 
     @Override
     public List<Integer> findLocationIdsByEnvironmentId(int environmentId) {
         return dbInteractions.query(
-                "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")",
-                rs -> rs.getInt("location_id"));
+                "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)",
+                rs -> rs.getInt("location_id"), environmentId);
     }
 
     @Override
     public List<Integer> findGridIdsByEnvironmentId(int environmentId) {
         return dbInteractions.query(
-                "SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId,
-                rs -> rs.getInt("grid_id"));
+                "SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?",
+                rs -> rs.getInt("grid_id"), environmentId);
     }
 
     @Override
     public boolean deleteEntityLocation(int entityId) {
-        return dbInteractions.update("DELETE FROM viron.entity_location WHERE entity_id = " + entityId);
+        return dbInteractions.update("DELETE FROM viron.entity_location WHERE entity_id = ?", entityId);
     }
 
     @Override
     public boolean deleteLocationGrid(int locationId) {
-        return dbInteractions.update("DELETE FROM viron.location_grid WHERE location_id = " + locationId);
+        return dbInteractions.update("DELETE FROM viron.location_grid WHERE location_id = ?", locationId);
     }
 
     @Override
     public boolean deleteGridEnvironment(int gridId) {
-        return dbInteractions.update("DELETE FROM viron.grid_environment WHERE grid_id = " + gridId);
+        return dbInteractions.update("DELETE FROM viron.grid_environment WHERE grid_id = ?", gridId);
     }
 
     @Override
     public boolean deleteEntity(int entityId) {
-        return dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = " + entityId);
+        return dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = ?", entityId);
     }
 
     @Override
     public boolean deleteLocation(int locationId) {
-        return dbInteractions.update("DELETE FROM viron.location WHERE location_id = " + locationId);
+        return dbInteractions.update("DELETE FROM viron.location WHERE location_id = ?", locationId);
     }
 
     @Override
     public boolean deleteGrid(int gridId) {
-        return dbInteractions.update("DELETE FROM viron.grid WHERE grid_id = " + gridId);
+        return dbInteractions.update("DELETE FROM viron.grid WHERE grid_id = ?", gridId);
     }
 
     private Environment mapResultSetToEnvironment(ResultSet rs) throws SQLException {

--- a/src/main/java/preponderous/viron/repositories/GridRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/GridRepositoryImpl.java
@@ -31,21 +31,21 @@ public class GridRepositoryImpl implements GridRepository {
 
     @Override
     public Optional<Grid> findById(int id) {
-        return dbInteractions.queryOne("SELECT * FROM viron.grid WHERE grid_id = " + id, this::mapResultSetToGrid);
+        return dbInteractions.queryOne("SELECT * FROM viron.grid WHERE grid_id = ?", this::mapResultSetToGrid, id);
     }
 
     @Override
     public List<Grid> findByEnvironmentId(int environmentId) {
         String query = "SELECT * FROM viron.grid WHERE grid_id in " +
-                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")";
-        return dbInteractions.query(query, this::mapResultSetToGrid);
+                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)";
+        return dbInteractions.query(query, this::mapResultSetToGrid, environmentId);
     }
 
     @Override
     public Optional<Grid> findByEntityId(int entityId) {
         String query = "SELECT * FROM viron.grid WHERE grid_id in " +
                 "(SELECT grid_id FROM viron.location_grid WHERE location_id in " +
-                "(SELECT location_id FROM viron.entity_location WHERE entity_id = " + entityId + "))";
-        return dbInteractions.queryOne(query, this::mapResultSetToGrid);
+                "(SELECT location_id FROM viron.entity_location WHERE entity_id = ?))";
+        return dbInteractions.queryOne(query, this::mapResultSetToGrid, entityId);
     }
 }

--- a/src/main/java/preponderous/viron/repositories/LocationRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/LocationRepositoryImpl.java
@@ -31,77 +31,74 @@ public class LocationRepositoryImpl implements LocationRepository {
 
     @Override
     public Optional<Location> findById(int id) {
-        return dbInteractions.queryOne("SELECT * FROM viron.location WHERE location_id = " + id,
-                this::mapResultSetToLocation);
+        return dbInteractions.queryOne("SELECT * FROM viron.location WHERE location_id = ?",
+                this::mapResultSetToLocation, id);
     }
 
     @Override
     public List<Location> findByEnvironmentId(int environmentId) {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
-                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + "))";
-        return dbInteractions.query(query, this::mapResultSetToLocation);
+                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?))";
+        return dbInteractions.query(query, this::mapResultSetToLocation, environmentId);
     }
 
     @Override
     public List<Location> findByGridId(int gridId) {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
-                "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + ")";
-        return dbInteractions.query(query, this::mapResultSetToLocation);
+                "(SELECT location_id FROM viron.location_grid WHERE grid_id = ?)";
+        return dbInteractions.query(query, this::mapResultSetToLocation, gridId);
     }
 
     @Override
     public Optional<Location> findByEntityId(int entityId) {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
-                "(SELECT location_id FROM viron.entity_location WHERE entity_id = " + entityId + ")";
-        return dbInteractions.queryOne(query, this::mapResultSetToLocation);
+                "(SELECT location_id FROM viron.entity_location WHERE entity_id = ?)";
+        return dbInteractions.queryOne(query, this::mapResultSetToLocation, entityId);
     }
 
     @Override
     public boolean addEntityToLocation(int entityId, int locationId) {
-        String query = "INSERT INTO viron.entity_location (entity_id, location_id) VALUES (" +
-                entityId + ", " + locationId + ")";
-        return dbInteractions.update(query);
+        String query = "INSERT INTO viron.entity_location (entity_id, location_id) VALUES (?, ?)";
+        return dbInteractions.update(query, entityId, locationId);
     }
 
     @Override
     public boolean removeEntityFromLocation(int entityId, int locationId) {
-        String query = "DELETE FROM viron.entity_location WHERE entity_id = " +
-                entityId + " AND location_id = " + locationId;
-        return dbInteractions.update(query);
+        String query = "DELETE FROM viron.entity_location WHERE entity_id = ? AND location_id = ?";
+        return dbInteractions.update(query, entityId, locationId);
     }
 
     @Override
     public boolean removeEntityFromCurrentLocation(int entityId) {
-        String query = "DELETE FROM viron.entity_location WHERE entity_id = " + entityId;
-        return dbInteractions.update(query);
+        String query = "DELETE FROM viron.entity_location WHERE entity_id = ?";
+        return dbInteractions.update(query, entityId);
     }
 
     @Override
     public List<Integer> getEntityIdsAtLocation(int locationId) {
-        String query = "SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId;
-        return dbInteractions.query(query, rs -> rs.getInt("entity_id"));
+        String query = "SELECT entity_id FROM viron.entity_location WHERE location_id = ?";
+        return dbInteractions.query(query, rs -> rs.getInt("entity_id"), locationId);
     }
 
     @Override
     public List<Location> findUnoccupiedByGridId(int gridId) {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
-                "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + ") " +
+                "(SELECT location_id FROM viron.location_grid WHERE grid_id = ?) " +
                 "AND location_id not in (SELECT location_id FROM viron.entity_location)";
-        return dbInteractions.query(query, this::mapResultSetToLocation);
+        return dbInteractions.query(query, this::mapResultSetToLocation, gridId);
     }
 
     @Override
     public Optional<Integer> getGridIdOfLocation(int locationId) {
-        String query = "SELECT grid_id FROM viron.location_grid WHERE location_id = " + locationId;
-        return dbInteractions.queryOne(query, rs -> rs.getInt("grid_id"));
+        String query = "SELECT grid_id FROM viron.location_grid WHERE location_id = ?";
+        return dbInteractions.queryOne(query, rs -> rs.getInt("grid_id"), locationId);
     }
 
     @Override
     public boolean moveEntityToLocation(int entityId, int targetLocationId) {
         // Single atomic statement: re-point the entity's existing placement to the target.
-        String query = "UPDATE viron.entity_location SET location_id = " + targetLocationId +
-                " WHERE entity_id = " + entityId;
-        return dbInteractions.update(query);
+        String query = "UPDATE viron.entity_location SET location_id = ? WHERE entity_id = ?";
+        return dbInteractions.update(query, targetLocationId, entityId);
     }
 }

--- a/src/test/java/preponderous/viron/factories/EntityFactoryTest.java
+++ b/src/test/java/preponderous/viron/factories/EntityFactoryTest.java
@@ -29,7 +29,7 @@ public class EntityFactoryTest {
     @Test
     public void testCreateEntity_Success_ReturnsEntity() {
         Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ID_QUERY), any())).thenReturn(Optional.of(5));
-        Mockito.when(dbInteractions.update(anyString(), any(), any())).thenReturn(true);
+        Mockito.when(dbInteractions.update(anyString(), any(), any(), any())).thenReturn(true);
 
         EntityFactory factory = new EntityFactory(dbInteractions);
 
@@ -51,13 +51,13 @@ public class EntityFactoryTest {
         assertThatThrownBy(() -> factory.createEntity("Bob"))
                 .isInstanceOf(EntityCreationException.class)
                 .hasMessage("Failed to get next entity id");
-        verify(dbInteractions, never()).update(anyString(), any(), any());
+        verify(dbInteractions, never()).update(anyString(), any(), any(), any());
     }
 
     @Test
     public void testCreateEntity_InsertFails_Throws() {
         Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ID_QUERY), any())).thenReturn(Optional.of(5));
-        Mockito.when(dbInteractions.update(anyString(), any(), any())).thenReturn(false);
+        Mockito.when(dbInteractions.update(anyString(), any(), any(), any())).thenReturn(false);
 
         EntityFactory factory = new EntityFactory(dbInteractions);
 

--- a/src/test/java/preponderous/viron/repositories/EntityRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/EntityRepositoryImplTest.java
@@ -88,7 +88,7 @@ public class EntityRepositoryImplTest {
         int entityId = 1;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
 
-        Mockito.when(dbInteractions.<Entity>queryOne(eq("SELECT * FROM viron.entity WHERE entity_id = " + entityId), any())).thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(dbInteractions.<Entity>queryOne(eq("SELECT * FROM viron.entity WHERE entity_id = ?"), any(), eq(entityId))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true); // Entity is found
         Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(entityId);
         Mockito.when(mockResultSet.getString("name")).thenReturn("Entity1");
@@ -112,7 +112,7 @@ public class EntityRepositoryImplTest {
         int entityId = 1;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
 
-        Mockito.when(dbInteractions.<Entity>queryOne(eq("SELECT * FROM viron.entity WHERE entity_id = " + entityId), any())).thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(dbInteractions.<Entity>queryOne(eq("SELECT * FROM viron.entity WHERE entity_id = ?"), any(), eq(entityId))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false); // Entity is not found
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -128,7 +128,7 @@ public class EntityRepositoryImplTest {
     public void testFindById_ReturnsEmptyWhenQueryFails() {
         // Arrange
         int entityId = 1;
-        Mockito.when(dbInteractions.<Entity>queryOne(eq("SELECT * FROM viron.entity WHERE entity_id = " + entityId), any())).thenReturn(Optional.empty()); // ResultSet is null
+        Mockito.when(dbInteractions.<Entity>queryOne(eq("SELECT * FROM viron.entity WHERE entity_id = ?"), any(), eq(entityId))).thenReturn(Optional.empty()); // ResultSet is null
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
 
@@ -147,7 +147,7 @@ public class EntityRepositoryImplTest {
         Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
                         "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
                         "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
-                        "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))"), any()))
+                        "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)))"), any(), eq(environmentId)))
                 .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false); // 2 entities in the result set
         Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(1, 2);
@@ -177,7 +177,7 @@ public class EntityRepositoryImplTest {
         Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
                         "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
                         "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
-                        "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))"), any()))
+                        "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)))"), any(), eq(environmentId)))
                 .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false); // No entities in the result set
 
@@ -197,7 +197,7 @@ public class EntityRepositoryImplTest {
         Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
                         "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
                         "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
-                        "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))"), any()))
+                        "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)))"), any(), eq(environmentId)))
                 .thenReturn(Collections.emptyList()); // ResultSet is null
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -216,7 +216,7 @@ public class EntityRepositoryImplTest {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
         Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
                         "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
-                        "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + "))"), any()))
+                        "(SELECT location_id FROM viron.location_grid WHERE grid_id = ?))"), any(), eq(gridId)))
                 .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false); // 2 entities in the result set
         Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(1, 2);
@@ -245,7 +245,7 @@ public class EntityRepositoryImplTest {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
         Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
                         "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
-                        "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + "))"), any()))
+                        "(SELECT location_id FROM viron.location_grid WHERE grid_id = ?))"), any(), eq(gridId)))
                 .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false); // No entities in the result set
 
@@ -264,7 +264,7 @@ public class EntityRepositoryImplTest {
         int gridId = 10;
         Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
                         "(SELECT entity_id FROM viron.entity_location WHERE location_id in " +
-                        "(SELECT location_id FROM viron.location_grid WHERE grid_id = " + gridId + "))"), any()))
+                        "(SELECT location_id FROM viron.location_grid WHERE grid_id = ?))"), any(), eq(gridId)))
                 .thenReturn(Collections.emptyList()); // ResultSet is null
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -282,7 +282,7 @@ public class EntityRepositoryImplTest {
         int locationId = 15;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
         Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
-                        "(SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId + ")"), any()))
+                        "(SELECT entity_id FROM viron.entity_location WHERE location_id = ?)"), any(), eq(locationId)))
                 .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false); // 2 entities in the result set
         Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(1, 2);
@@ -310,7 +310,7 @@ public class EntityRepositoryImplTest {
         int locationId = 15;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
         Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
-                        "(SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId + ")"), any()))
+                        "(SELECT entity_id FROM viron.entity_location WHERE location_id = ?)"), any(), eq(locationId)))
                 .thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false); // No entities in the result set
 
@@ -328,7 +328,7 @@ public class EntityRepositoryImplTest {
         // Arrange
         int locationId = 15;
         Mockito.when(dbInteractions.<Entity>query(eq("SELECT * FROM viron.entity WHERE entity_id in " +
-                        "(SELECT entity_id FROM viron.entity_location WHERE location_id = " + locationId + ")"), any()))
+                        "(SELECT entity_id FROM viron.entity_location WHERE location_id = ?)"), any(), eq(locationId)))
                 .thenReturn(Collections.emptyList()); // ResultSet is null
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -418,7 +418,7 @@ public class EntityRepositoryImplTest {
 
         // Mock finding the entity by ID
         ResultSet entityResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Entity>queryOne(eq("SELECT * FROM viron.entity WHERE entity_id = 100"), any()))
+        Mockito.when(dbInteractions.<Entity>queryOne(eq("SELECT * FROM viron.entity WHERE entity_id = ?"), any(), eq(100)))
                 .thenAnswer(mapsFirstRow(entityResultSet));
         Mockito.when(entityResultSet.next()).thenReturn(true);
         Mockito.when(entityResultSet.getInt("entity_id")).thenReturn(100);
@@ -475,7 +475,7 @@ public class EntityRepositoryImplTest {
     public void testDeleteById_DeletesEntitySuccessfully_ReturnsTrue() {
         // Arrange
         int entityId = 1;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = " + entityId))
+        Mockito.when(dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = ?", entityId))
                 .thenReturn(true);
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -491,7 +491,7 @@ public class EntityRepositoryImplTest {
     public void testDeleteById_EntityNotFound_ReturnsFalse() {
         // Arrange
         int entityId = 1;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = " + entityId))
+        Mockito.when(dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = ?", entityId))
                 .thenReturn(false);
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -507,7 +507,7 @@ public class EntityRepositoryImplTest {
     public void testDeleteById_HandlesSQLExceptionGracefully_ReturnsFalse() {
         // Arrange
         int entityId = 1;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = " + entityId))
+        Mockito.when(dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = ?", entityId))
                 .thenReturn(false); // Instead of throwing SQLException, just return false
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -524,7 +524,7 @@ public class EntityRepositoryImplTest {
         // Arrange
         int entityId = 1;
         String newName = "UpdatedEntityName";
-        Mockito.when(dbInteractions.update("UPDATE viron.entity SET name = ? WHERE entity_id = 1", "UpdatedEntityName"))
+        Mockito.when(dbInteractions.update("UPDATE viron.entity SET name = ? WHERE entity_id = ?", "UpdatedEntityName", 1))
                 .thenReturn(true);
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -541,7 +541,7 @@ public class EntityRepositoryImplTest {
         // Arrange
         int entityId = 1;
         String newName = "UpdatedEntityName";
-        Mockito.when(dbInteractions.update("UPDATE viron.entity SET name = ? WHERE entity_id = 1", "UpdatedEntityName"))
+        Mockito.when(dbInteractions.update("UPDATE viron.entity SET name = ? WHERE entity_id = ?", "UpdatedEntityName", 1))
                 .thenReturn(false);
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
@@ -558,7 +558,7 @@ public class EntityRepositoryImplTest {
         // Arrange
         int entityId = 1;
         String newName = "UpdatedEntityName";
-        Mockito.when(dbInteractions.update("UPDATE viron.entity SET name = ? WHERE entity_id = 1", "UpdatedEntityName"))
+        Mockito.when(dbInteractions.update("UPDATE viron.entity SET name = ? WHERE entity_id = ?", "UpdatedEntityName", 1))
                 .thenReturn(false); // Instead of throwing SQLException, just return false
 
         EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);

--- a/src/test/java/preponderous/viron/repositories/EnvironmentRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/EnvironmentRepositoryImplTest.java
@@ -79,7 +79,7 @@ public class EnvironmentRepositoryImplTest {
     public void testFindById_ReturnsEnvironmentWhenRowExists() throws SQLException {
         int id = 1;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = " + id), any())).thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = ?"), any(), eq(id))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("environment_id")).thenReturn(id);
         Mockito.when(mockResultSet.getString("name")).thenReturn("Env1");
@@ -99,7 +99,7 @@ public class EnvironmentRepositoryImplTest {
     public void testFindById_ReturnsEmptyWhenNoRow() throws SQLException {
         int id = 1;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = " + id), any())).thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = ?"), any(), eq(id))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -112,7 +112,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindById_ReturnsEmptyWhenQueryFails() {
         int id = 1;
-        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = " + id), any())).thenReturn(Optional.empty());
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = ?"), any(), eq(id))).thenReturn(Optional.empty());
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -175,7 +175,7 @@ public class EnvironmentRepositoryImplTest {
     public void testFindByEntityId_ReturnsEnvironmentWhenRowExists() throws SQLException {
         int entityId = 7;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")"), any())).thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = ?)"), any(), eq(entityId))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("environment_id")).thenReturn(3);
         Mockito.when(mockResultSet.getString("name")).thenReturn("Env3");
@@ -195,7 +195,7 @@ public class EnvironmentRepositoryImplTest {
     public void testFindByEntityId_ReturnsEmptyWhenNoRow() throws SQLException {
         int entityId = 7;
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")"), any())).thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = ?)"), any(), eq(entityId))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -208,7 +208,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindByEntityId_ReturnsEmptyWhenQueryFails() {
         int entityId = 7;
-        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = " + entityId + ")"), any())).thenReturn(Optional.empty());
+        Mockito.when(dbInteractions.<Environment>queryOne(eq("SELECT * FROM viron.environment WHERE environment_id = (SELECT environment_id FROM viron.entity WHERE entity_id = ?)"), any(), eq(entityId))).thenReturn(Optional.empty());
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -236,7 +236,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteById_ReturnsTrueWhenUpdateSucceeds() {
         int id = 1;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.environment WHERE environment_id = " + id)).thenReturn(true);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.environment WHERE environment_id = ?", id)).thenReturn(true);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -246,7 +246,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteById_ReturnsFalseWhenUpdateFails() {
         int id = 1;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.environment WHERE environment_id = " + id)).thenReturn(false);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.environment WHERE environment_id = ?", id)).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -259,7 +259,7 @@ public class EnvironmentRepositoryImplTest {
     public void testUpdateName_ReturnsTrueWhenUpdateSucceeds() {
         int id = 1;
         String name = "NewName";
-        Mockito.when(dbInteractions.update("UPDATE viron.environment SET name = ? WHERE environment_id = " + id, name)).thenReturn(true);
+        Mockito.when(dbInteractions.update("UPDATE viron.environment SET name = ? WHERE environment_id = ?", name, id)).thenReturn(true);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -270,7 +270,7 @@ public class EnvironmentRepositoryImplTest {
     public void testUpdateName_ReturnsFalseWhenUpdateFails() {
         int id = 1;
         String name = "NewName";
-        Mockito.when(dbInteractions.update("UPDATE viron.environment SET name = ? WHERE environment_id = " + id, name)).thenReturn(false);
+        Mockito.when(dbInteractions.update("UPDATE viron.environment SET name = ? WHERE environment_id = ?", name, id)).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -282,9 +282,9 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindEntityIdsByEnvironmentId_ReturnsIdsWhenResultSetIsNotEmpty() throws SQLException {
         int environmentId = 5;
-        String query = "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))";
+        String query = "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)))";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any(), eq(environmentId))).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false);
         Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(11, 22);
 
@@ -298,9 +298,9 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindEntityIdsByEnvironmentId_ReturnsEmptyListWhenResultSetIsEmpty() throws SQLException {
         int environmentId = 5;
-        String query = "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))";
+        String query = "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)))";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any(), eq(environmentId))).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -313,8 +313,8 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindEntityIdsByEnvironmentId_ReturnsEmptyListWhenQueryFails() {
         int environmentId = 5;
-        String query = "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")))";
-        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenReturn(Collections.emptyList());
+        String query = "SELECT entity_id FROM viron.entity WHERE entity_id in (SELECT entity_id FROM viron.entity_location WHERE location_id in (SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)))";
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any(), eq(environmentId))).thenReturn(Collections.emptyList());
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -328,9 +328,9 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindLocationIdsByEnvironmentId_ReturnsIdsWhenResultSetIsNotEmpty() throws SQLException {
         int environmentId = 5;
-        String query = "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")";
+        String query = "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any(), eq(environmentId))).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false);
         Mockito.when(mockResultSet.getInt("location_id")).thenReturn(33, 44);
 
@@ -344,9 +344,9 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindLocationIdsByEnvironmentId_ReturnsEmptyListWhenResultSetIsEmpty() throws SQLException {
         int environmentId = 5;
-        String query = "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")";
+        String query = "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any(), eq(environmentId))).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -359,8 +359,8 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindLocationIdsByEnvironmentId_ReturnsEmptyListWhenQueryFails() {
         int environmentId = 5;
-        String query = "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId + ")";
-        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenReturn(Collections.emptyList());
+        String query = "SELECT location_id FROM viron.location_grid WHERE grid_id in (SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)";
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any(), eq(environmentId))).thenReturn(Collections.emptyList());
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -374,9 +374,9 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindGridIdsByEnvironmentId_ReturnsIdsWhenResultSetIsNotEmpty() throws SQLException {
         int environmentId = 5;
-        String query = "SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId;
+        String query = "SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any(), eq(environmentId))).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false);
         Mockito.when(mockResultSet.getInt("grid_id")).thenReturn(55, 66);
 
@@ -390,9 +390,9 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindGridIdsByEnvironmentId_ReturnsEmptyListWhenResultSetIsEmpty() throws SQLException {
         int environmentId = 5;
-        String query = "SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId;
+        String query = "SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any(), eq(environmentId))).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
@@ -405,8 +405,8 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testFindGridIdsByEnvironmentId_ReturnsEmptyListWhenQueryFails() {
         int environmentId = 5;
-        String query = "SELECT grid_id FROM viron.grid_environment WHERE environment_id = " + environmentId;
-        Mockito.when(dbInteractions.<Integer>query(eq(query), any())).thenReturn(Collections.emptyList());
+        String query = "SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?";
+        Mockito.when(dbInteractions.<Integer>query(eq(query), any(), eq(environmentId))).thenReturn(Collections.emptyList());
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -420,7 +420,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteEntityLocation_ReturnsTrueWhenUpdateSucceeds() {
         int entityId = 9;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.entity_location WHERE entity_id = " + entityId)).thenReturn(true);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.entity_location WHERE entity_id = ?", entityId)).thenReturn(true);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -430,7 +430,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteEntityLocation_ReturnsFalseWhenUpdateFails() {
         int entityId = 9;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.entity_location WHERE entity_id = " + entityId)).thenReturn(false);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.entity_location WHERE entity_id = ?", entityId)).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -442,7 +442,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteLocationGrid_ReturnsTrueWhenUpdateSucceeds() {
         int locationId = 9;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.location_grid WHERE location_id = " + locationId)).thenReturn(true);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.location_grid WHERE location_id = ?", locationId)).thenReturn(true);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -452,7 +452,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteLocationGrid_ReturnsFalseWhenUpdateFails() {
         int locationId = 9;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.location_grid WHERE location_id = " + locationId)).thenReturn(false);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.location_grid WHERE location_id = ?", locationId)).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -464,7 +464,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteGridEnvironment_ReturnsTrueWhenUpdateSucceeds() {
         int gridId = 9;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.grid_environment WHERE grid_id = " + gridId)).thenReturn(true);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.grid_environment WHERE grid_id = ?", gridId)).thenReturn(true);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -474,7 +474,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteGridEnvironment_ReturnsFalseWhenUpdateFails() {
         int gridId = 9;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.grid_environment WHERE grid_id = " + gridId)).thenReturn(false);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.grid_environment WHERE grid_id = ?", gridId)).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -486,7 +486,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteEntity_ReturnsTrueWhenUpdateSucceeds() {
         int entityId = 9;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = " + entityId)).thenReturn(true);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = ?", entityId)).thenReturn(true);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -496,7 +496,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteEntity_ReturnsFalseWhenUpdateFails() {
         int entityId = 9;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = " + entityId)).thenReturn(false);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = ?", entityId)).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -508,7 +508,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteLocation_ReturnsTrueWhenUpdateSucceeds() {
         int locationId = 9;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.location WHERE location_id = " + locationId)).thenReturn(true);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.location WHERE location_id = ?", locationId)).thenReturn(true);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -518,7 +518,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteLocation_ReturnsFalseWhenUpdateFails() {
         int locationId = 9;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.location WHERE location_id = " + locationId)).thenReturn(false);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.location WHERE location_id = ?", locationId)).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -530,7 +530,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteGrid_ReturnsTrueWhenUpdateSucceeds() {
         int gridId = 9;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.grid WHERE grid_id = " + gridId)).thenReturn(true);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.grid WHERE grid_id = ?", gridId)).thenReturn(true);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 
@@ -540,7 +540,7 @@ public class EnvironmentRepositoryImplTest {
     @Test
     public void testDeleteGrid_ReturnsFalseWhenUpdateFails() {
         int gridId = 9;
-        Mockito.when(dbInteractions.update("DELETE FROM viron.grid WHERE grid_id = " + gridId)).thenReturn(false);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.grid WHERE grid_id = ?", gridId)).thenReturn(false);
 
         EnvironmentRepositoryImpl repository = new EnvironmentRepositoryImpl(dbInteractions);
 

--- a/src/test/java/preponderous/viron/repositories/GridRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/GridRepositoryImplTest.java
@@ -74,7 +74,7 @@ public class GridRepositoryImplTest {
     @Test
     public void testFindById_ReturnsGridWhenRowExists() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Grid>queryOne(eq("SELECT * FROM viron.grid WHERE grid_id = 1"), any())).thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(dbInteractions.<Grid>queryOne(eq("SELECT * FROM viron.grid WHERE grid_id = ?"), any(), eq(1))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("grid_id")).thenReturn(1);
         Mockito.when(mockResultSet.getInt("rows")).thenReturn(10);
@@ -93,7 +93,7 @@ public class GridRepositoryImplTest {
     @Test
     public void testFindById_ReturnsEmptyWhenNoRow() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Grid>queryOne(eq("SELECT * FROM viron.grid WHERE grid_id = 99"), any())).thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(dbInteractions.<Grid>queryOne(eq("SELECT * FROM viron.grid WHERE grid_id = ?"), any(), eq(99))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
@@ -103,7 +103,7 @@ public class GridRepositoryImplTest {
 
     @Test
     public void testFindById_ReturnsEmptyWhenQueryFails() {
-        Mockito.when(dbInteractions.<Grid>queryOne(eq("SELECT * FROM viron.grid WHERE grid_id = 1"), any())).thenReturn(Optional.empty());
+        Mockito.when(dbInteractions.<Grid>queryOne(eq("SELECT * FROM viron.grid WHERE grid_id = ?"), any(), eq(1))).thenReturn(Optional.empty());
 
         GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
 
@@ -115,9 +115,9 @@ public class GridRepositoryImplTest {
     @Test
     public void testFindByEnvironmentId_ReturnsGridsWhenRowsExist() throws SQLException {
         String query = "SELECT * FROM viron.grid WHERE grid_id in " +
-                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = 7)";
+                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Grid>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
+        Mockito.when(dbInteractions.<Grid>query(eq(query), any(), eq(7))).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, false);
         Mockito.when(mockResultSet.getInt("grid_id")).thenReturn(3);
         Mockito.when(mockResultSet.getInt("rows")).thenReturn(8);
@@ -134,8 +134,8 @@ public class GridRepositoryImplTest {
     @Test
     public void testFindByEnvironmentId_ReturnsEmptyListWhenQueryFails() {
         String query = "SELECT * FROM viron.grid WHERE grid_id in " +
-                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = 7)";
-        Mockito.when(dbInteractions.<Grid>query(eq(query), any())).thenReturn(Collections.emptyList());
+                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?)";
+        Mockito.when(dbInteractions.<Grid>query(eq(query), any(), eq(7))).thenReturn(Collections.emptyList());
 
         GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
 
@@ -148,9 +148,9 @@ public class GridRepositoryImplTest {
     public void testFindByEntityId_ReturnsGridWhenRowExists() throws SQLException {
         String query = "SELECT * FROM viron.grid WHERE grid_id in " +
                 "(SELECT grid_id FROM viron.location_grid WHERE location_id in " +
-                "(SELECT location_id FROM viron.entity_location WHERE entity_id = 42))";
+                "(SELECT location_id FROM viron.entity_location WHERE entity_id = ?))";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Grid>queryOne(eq(query), any())).thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(dbInteractions.<Grid>queryOne(eq(query), any(), eq(42))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("grid_id")).thenReturn(9);
         Mockito.when(mockResultSet.getInt("rows")).thenReturn(4);
@@ -168,8 +168,8 @@ public class GridRepositoryImplTest {
     public void testFindByEntityId_ReturnsEmptyWhenQueryFails() {
         String query = "SELECT * FROM viron.grid WHERE grid_id in " +
                 "(SELECT grid_id FROM viron.location_grid WHERE location_id in " +
-                "(SELECT location_id FROM viron.entity_location WHERE entity_id = 42))";
-        Mockito.when(dbInteractions.<Grid>queryOne(eq(query), any())).thenReturn(Optional.empty());
+                "(SELECT location_id FROM viron.entity_location WHERE entity_id = ?))";
+        Mockito.when(dbInteractions.<Grid>queryOne(eq(query), any(), eq(42))).thenReturn(Optional.empty());
 
         GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
 

--- a/src/test/java/preponderous/viron/repositories/LocationRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/LocationRepositoryImplTest.java
@@ -74,7 +74,7 @@ public class LocationRepositoryImplTest {
     @Test
     public void testFindById_ReturnsLocationWhenRowExists() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Location>queryOne(eq("SELECT * FROM viron.location WHERE location_id = 1"), any())).thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(dbInteractions.<Location>queryOne(eq("SELECT * FROM viron.location WHERE location_id = ?"), any(), eq(1))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("location_id")).thenReturn(1);
         Mockito.when(mockResultSet.getInt("x")).thenReturn(3);
@@ -93,7 +93,7 @@ public class LocationRepositoryImplTest {
     @Test
     public void testFindById_ReturnsEmptyWhenNoRow() throws SQLException {
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Location>queryOne(eq("SELECT * FROM viron.location WHERE location_id = 99"), any())).thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(dbInteractions.<Location>queryOne(eq("SELECT * FROM viron.location WHERE location_id = ?"), any(), eq(99))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
@@ -103,7 +103,7 @@ public class LocationRepositoryImplTest {
 
     @Test
     public void testFindById_ReturnsEmptyWhenQueryFails() {
-        Mockito.when(dbInteractions.<Location>queryOne(eq("SELECT * FROM viron.location WHERE location_id = 1"), any())).thenReturn(Optional.empty());
+        Mockito.when(dbInteractions.<Location>queryOne(eq("SELECT * FROM viron.location WHERE location_id = ?"), any(), eq(1))).thenReturn(Optional.empty());
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -116,9 +116,9 @@ public class LocationRepositoryImplTest {
     public void testFindByEnvironmentId_ReturnsLocationsWhenRowsExist() throws SQLException {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
-                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = 7))";
+                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?))";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Location>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
+        Mockito.when(dbInteractions.<Location>query(eq(query), any(), eq(7))).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, false);
         Mockito.when(mockResultSet.getInt("location_id")).thenReturn(5);
         Mockito.when(mockResultSet.getInt("x")).thenReturn(1);
@@ -136,8 +136,8 @@ public class LocationRepositoryImplTest {
     public void testFindByEnvironmentId_ReturnsEmptyListWhenQueryFails() {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
                 "(SELECT location_id FROM viron.location_grid WHERE grid_id in " +
-                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = 7))";
-        Mockito.when(dbInteractions.<Location>query(eq(query), any())).thenReturn(Collections.emptyList());
+                "(SELECT grid_id FROM viron.grid_environment WHERE environment_id = ?))";
+        Mockito.when(dbInteractions.<Location>query(eq(query), any(), eq(7))).thenReturn(Collections.emptyList());
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -149,9 +149,9 @@ public class LocationRepositoryImplTest {
     @Test
     public void testFindByGridId_ReturnsLocationsWhenRowsExist() throws SQLException {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
-                "(SELECT location_id FROM viron.location_grid WHERE grid_id = 3)";
+                "(SELECT location_id FROM viron.location_grid WHERE grid_id = ?)";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Location>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
+        Mockito.when(dbInteractions.<Location>query(eq(query), any(), eq(3))).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false);
         Mockito.when(mockResultSet.getInt("location_id")).thenReturn(5, 6);
         Mockito.when(mockResultSet.getInt("x")).thenReturn(1, 2);
@@ -169,8 +169,8 @@ public class LocationRepositoryImplTest {
     @Test
     public void testFindByGridId_ReturnsEmptyListWhenQueryFails() {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
-                "(SELECT location_id FROM viron.location_grid WHERE grid_id = 3)";
-        Mockito.when(dbInteractions.<Location>query(eq(query), any())).thenReturn(Collections.emptyList());
+                "(SELECT location_id FROM viron.location_grid WHERE grid_id = ?)";
+        Mockito.when(dbInteractions.<Location>query(eq(query), any(), eq(3))).thenReturn(Collections.emptyList());
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -182,10 +182,10 @@ public class LocationRepositoryImplTest {
     @Test
     public void testFindUnoccupiedByGridId_ReturnsLocationsWhenRowsExist() throws SQLException {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
-                "(SELECT location_id FROM viron.location_grid WHERE grid_id = 3) " +
+                "(SELECT location_id FROM viron.location_grid WHERE grid_id = ?) " +
                 "AND location_id not in (SELECT location_id FROM viron.entity_location)";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Location>query(eq(query), any())).thenAnswer(mapsAllRows(mockResultSet));
+        Mockito.when(dbInteractions.<Location>query(eq(query), any(), eq(3))).thenAnswer(mapsAllRows(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true, true, false);
         Mockito.when(mockResultSet.getInt("location_id")).thenReturn(5, 6);
         Mockito.when(mockResultSet.getInt("x")).thenReturn(1, 2);
@@ -203,9 +203,9 @@ public class LocationRepositoryImplTest {
     @Test
     public void testFindUnoccupiedByGridId_ReturnsEmptyListWhenQueryFails() {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
-                "(SELECT location_id FROM viron.location_grid WHERE grid_id = 3) " +
+                "(SELECT location_id FROM viron.location_grid WHERE grid_id = ?) " +
                 "AND location_id not in (SELECT location_id FROM viron.entity_location)";
-        Mockito.when(dbInteractions.<Location>query(eq(query), any())).thenReturn(Collections.emptyList());
+        Mockito.when(dbInteractions.<Location>query(eq(query), any(), eq(3))).thenReturn(Collections.emptyList());
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -217,9 +217,9 @@ public class LocationRepositoryImplTest {
     @Test
     public void testFindByEntityId_ReturnsLocationWhenRowExists() throws SQLException {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
-                "(SELECT location_id FROM viron.entity_location WHERE entity_id = 42)";
+                "(SELECT location_id FROM viron.entity_location WHERE entity_id = ?)";
         ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Location>queryOne(eq(query), any())).thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(dbInteractions.<Location>queryOne(eq(query), any(), eq(42))).thenAnswer(mapsFirstRow(mockResultSet));
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.when(mockResultSet.getInt("location_id")).thenReturn(8);
         Mockito.when(mockResultSet.getInt("x")).thenReturn(0);
@@ -236,8 +236,8 @@ public class LocationRepositoryImplTest {
     @Test
     public void testFindByEntityId_ReturnsEmptyWhenQueryFails() {
         String query = "SELECT * FROM viron.location WHERE location_id in " +
-                "(SELECT location_id FROM viron.entity_location WHERE entity_id = 42)";
-        Mockito.when(dbInteractions.<Location>queryOne(eq(query), any())).thenReturn(Optional.empty());
+                "(SELECT location_id FROM viron.entity_location WHERE entity_id = ?)";
+        Mockito.when(dbInteractions.<Location>queryOne(eq(query), any(), eq(42))).thenReturn(Optional.empty());
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -248,19 +248,19 @@ public class LocationRepositoryImplTest {
 
     @Test
     public void testAddEntityToLocation_DelegatesToUpdateAndReturnsResult() {
-        String query = "INSERT INTO viron.entity_location (entity_id, location_id) VALUES (42, 8)";
-        Mockito.when(dbInteractions.update(query)).thenReturn(true);
+        String query = "INSERT INTO viron.entity_location (entity_id, location_id) VALUES (?, ?)";
+        Mockito.when(dbInteractions.update(query, 42, 8)).thenReturn(true);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
         assertThat(repository.addEntityToLocation(42, 8)).isTrue();
-        Mockito.verify(dbInteractions).update(query);
+        Mockito.verify(dbInteractions).update(query, 42, 8);
     }
 
     @Test
     public void testAddEntityToLocation_ReturnsFalseWhenUpdateFails() {
-        String query = "INSERT INTO viron.entity_location (entity_id, location_id) VALUES (42, 8)";
-        Mockito.when(dbInteractions.update(query)).thenReturn(false);
+        String query = "INSERT INTO viron.entity_location (entity_id, location_id) VALUES (?, ?)";
+        Mockito.when(dbInteractions.update(query, 42, 8)).thenReturn(false);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -269,24 +269,24 @@ public class LocationRepositoryImplTest {
 
     @Test
     public void testRemoveEntityFromLocation_DelegatesToUpdateAndReturnsResult() {
-        String query = "DELETE FROM viron.entity_location WHERE entity_id = 42 AND location_id = 8";
-        Mockito.when(dbInteractions.update(query)).thenReturn(true);
+        String query = "DELETE FROM viron.entity_location WHERE entity_id = ? AND location_id = ?";
+        Mockito.when(dbInteractions.update(query, 42, 8)).thenReturn(true);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
         assertThat(repository.removeEntityFromLocation(42, 8)).isTrue();
-        Mockito.verify(dbInteractions).update(query);
+        Mockito.verify(dbInteractions).update(query, 42, 8);
     }
 
     @Test
     public void testRemoveEntityFromCurrentLocation_DelegatesToUpdateAndReturnsResult() {
-        String query = "DELETE FROM viron.entity_location WHERE entity_id = 42";
-        Mockito.when(dbInteractions.update(query)).thenReturn(true);
+        String query = "DELETE FROM viron.entity_location WHERE entity_id = ?";
+        Mockito.when(dbInteractions.update(query, 42)).thenReturn(true);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
         assertThat(repository.removeEntityFromCurrentLocation(42)).isTrue();
-        Mockito.verify(dbInteractions).update(query);
+        Mockito.verify(dbInteractions).update(query, 42);
     }
 
     // ---- getEntityIdsAtLocation ----
@@ -294,7 +294,7 @@ public class LocationRepositoryImplTest {
     @Test
     public void testGetEntityIdsAtLocation_ReturnsIdsWhenResultSetNotEmpty() throws SQLException {
         ResultSet rs = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Integer>query(eq("SELECT entity_id FROM viron.entity_location WHERE location_id = 7"), any()))
+        Mockito.when(dbInteractions.<Integer>query(eq("SELECT entity_id FROM viron.entity_location WHERE location_id = ?"), any(), eq(7)))
                 .thenAnswer(mapsAllRows(rs));
         Mockito.when(rs.next()).thenReturn(true, true, false);
         Mockito.when(rs.getInt("entity_id")).thenReturn(11, 22);
@@ -306,7 +306,7 @@ public class LocationRepositoryImplTest {
 
     @Test
     public void testGetEntityIdsAtLocation_ReturnsEmptyWhenQueryFails() {
-        Mockito.when(dbInteractions.<Integer>query(Mockito.anyString(), any())).thenReturn(Collections.emptyList());
+        Mockito.when(dbInteractions.<Integer>query(Mockito.anyString(), any(), any())).thenReturn(Collections.emptyList());
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
@@ -318,7 +318,7 @@ public class LocationRepositoryImplTest {
     @Test
     public void testGetGridIdOfLocation_ReturnsGridWhenPresent() throws SQLException {
         ResultSet rs = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Integer>queryOne(eq("SELECT grid_id FROM viron.location_grid WHERE location_id = 5"), any()))
+        Mockito.when(dbInteractions.<Integer>queryOne(eq("SELECT grid_id FROM viron.location_grid WHERE location_id = ?"), any(), eq(5)))
                 .thenAnswer(mapsFirstRow(rs));
         Mockito.when(rs.next()).thenReturn(true);
         Mockito.when(rs.getInt("grid_id")).thenReturn(3);
@@ -331,7 +331,7 @@ public class LocationRepositoryImplTest {
     @Test
     public void testGetGridIdOfLocation_EmptyWhenNoRow() throws SQLException {
         ResultSet rs = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Integer>queryOne(Mockito.anyString(), any())).thenAnswer(mapsFirstRow(rs));
+        Mockito.when(dbInteractions.<Integer>queryOne(Mockito.anyString(), any(), any())).thenAnswer(mapsFirstRow(rs));
         Mockito.when(rs.next()).thenReturn(false);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
@@ -343,12 +343,12 @@ public class LocationRepositoryImplTest {
 
     @Test
     public void testMoveEntityToLocation_DelegatesToUpdate() {
-        String query = "UPDATE viron.entity_location SET location_id = 9 WHERE entity_id = 4";
-        Mockito.when(dbInteractions.update(query)).thenReturn(true);
+        String query = "UPDATE viron.entity_location SET location_id = ? WHERE entity_id = ?";
+        Mockito.when(dbInteractions.update(query, 9, 4)).thenReturn(true);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
         assertThat(repository.moveEntityToLocation(4, 9)).isTrue();
-        Mockito.verify(dbInteractions).update(query);
+        Mockito.verify(dbInteractions).update(query, 9, 4);
     }
 }


### PR DESCRIPTION
## Summary
- Repository (`EntityRepositoryImpl`, `EnvironmentRepositoryImpl`, `GridRepositoryImpl`, `LocationRepositoryImpl`) and factory (`EntityFactory`, `EnvironmentFactory`) query/update call sites concatenated `int` ids directly into SQL text instead of using the bind-parameter API `DbInteractions.query`/`queryOne`/`update` already expose (since #144/#174).
- All 40 concatenation sites are now `?` placeholders with the value passed as a bind parameter.
- This is **not** an injection fix (every interpolated value was a Java `int`, additionally constrained by `@Min(1)` on controllers) — it's a consistency and statement-caching improvement: the same repository sometimes bound one value and concatenated another, and concatenated ids produce a distinct SQL string per call instead of one reusable prepared plan.
- Updated the SQL string assertions in the corresponding repository/factory test files to match.

## Test plan
- [x] `mvn compile` — clean build (JDK 21 required per `pom.xml`; ran with `-Dmaven.compiler.executable=.../javac` since the default JVM here is 17)
- [x] `mvn test` — all 350 Java tests pass, 0 failures/errors (ran with `-Djvm=.../java` to fork the surefire JVM under JDK 21 for the same reason)
- No Python client changes — this PR only touches the Java data layer.

Closes #175

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
