### PR TITLE
feat: support optional grid metadata (name)

### DIFF
--- a/db-scripts/setup/create_tables.sql
+++ b/db-scripts/setup/create_tables.sql
@@ -18,11 +18,12 @@ CREATE TABLE IF NOT EXISTS viron.location (
     y INT NOT NULL
 );
 
--- grid table (grid_id, columns, rows)
+-- grid table (grid_id, columns, rows, name)
 CREATE TABLE IF NOT EXISTS viron.grid (
     grid_id INT PRIMARY KEY,
     rows INT NOT NULL,
-    columns INT NOT NULL
+    columns INT NOT NULL,
+    name VARCHAR(255)
 );
 
 -- environment table (environment_id, name, creation_date)

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -36,6 +36,7 @@ Deliver a working, tested API that supports:
 - [x] `GET /api/v1/grids/{id}` – Retrieve a grid by ID.
 - [x] `GET /api/v1/grids/environment/{environmentId}` – Retrieve all grids in an environment.
 - [x] `GET /api/v1/grids/entity/{entityId}` – Retrieve the grid containing a specific entity.
+- [x] `PATCH /api/v1/grids/{id}/name` – Update grid name (JSON body: `name`).
 
 ---
 
@@ -84,7 +85,8 @@ Deliver a working, tested API that supports:
 - [x] **EnvironmentDTO** – Public representation of an environment.
 - [x] **CreateEnvironmentRequest** – Request body for creating environments (name, number of grids, and grid dimensions as either `gridSize` or both `numRows` and `numColumns`).
 - [x] **UpdateEnvironmentNameRequest** – Request body for updating environment names.
-- [x] **GridDTO** – Public representation of a grid.
+- [x] **GridDTO** – Public representation of a grid (includes an optional `name`).
+- [x] **UpdateGridNameRequest** – Request body for updating grid names.
 - [x] **LocationDTO** – Public representation of a location.
 - [x] **EntityDTO** – Public representation of an entity.
 - [x] **CreateEntityRequest** – Request body for creating entities (name).

--- a/docs/openapi/viron-api.json
+++ b/docs/openapi/viron-api.json
@@ -226,6 +226,27 @@
         }
       }
     },
+    "/api/v1/grids/{id}/name": {
+      "patch": {
+        "summary": "Update grid name",
+        "parameters": [{ "$ref": "#/components/parameters/GridIdParam" }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/UpdateGridNameRequest" } }
+          }
+        },
+        "responses": {
+          "200": { "description": "Name updated" },
+          "404": {
+            "description": "Grid not found with that id",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/locations": {
       "get": {
         "summary": "Get all locations",
@@ -726,8 +747,14 @@
         "properties": {
           "gridId": { "type": "integer" },
           "rows": { "type": "integer" },
-          "columns": { "type": "integer" }
+          "columns": { "type": "integer" },
+          "name": { "type": "string", "nullable": true }
         }
+      },
+      "UpdateGridNameRequest": {
+        "type": "object",
+        "required": ["name"],
+        "properties": { "name": { "type": "string" } }
       },
       "LocationDTO": {
         "type": "object",

--- a/postman/Viron.postman_collection.json
+++ b/postman/Viron.postman_collection.json
@@ -334,6 +334,49 @@
             "description": "Get the grid containing an entity"
           },
           "response": []
+        },
+        {
+          "name": "PATCH /api/v1/grids/{id}/name",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "localhost:9999/api/v1/grids/:id/name",
+              "host": [
+                "localhost"
+              ],
+              "port": "9999",
+              "path": [
+                "api",
+                "v1",
+                "grids",
+                ":id",
+                "name"
+              ],
+              "variable": [
+                {
+                  "key": "id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Update grid name",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"example\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": []
         }
       ]
     },

--- a/src/main/java/preponderous/viron/controllers/GridController.java
+++ b/src/main/java/preponderous/viron/controllers/GridController.java
@@ -5,11 +5,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import preponderous.viron.dto.GridDto;
+import preponderous.viron.dto.UpdateGridNameRequest;
 import preponderous.viron.exceptions.NotFoundException;
+import preponderous.viron.exceptions.ServiceException;
 import preponderous.viron.mappers.GridMapper;
 import preponderous.viron.models.Grid;
 import preponderous.viron.repositories.GridRepository;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import java.util.List;
 
@@ -46,5 +49,19 @@ public class GridController {
         Grid grid = gridRepository.findByEntityId(entityId)
                 .orElseThrow(() -> new NotFoundException("Grid not found for entity: " + entityId));
         return gridMapper.toDto(grid);
+    }
+
+    @PatchMapping("/{id}/name")
+    public void updateGridName(@PathVariable @Min(1) int id, @Valid @RequestBody UpdateGridNameRequest request) {
+        String name = request.getName();
+        if (gridRepository.findById(id).isEmpty()) {
+            throw new NotFoundException("Grid not found with id: " + id);
+        }
+
+        if (!gridRepository.updateName(id, name)) {
+            throw new ServiceException("Failed to update name for grid " + id);
+        }
+
+        log.info("Updated name for grid {} to '{}'", id, name);
     }
 }

--- a/src/main/java/preponderous/viron/dto/GridDto.java
+++ b/src/main/java/preponderous/viron/dto/GridDto.java
@@ -18,4 +18,7 @@ public class GridDto {
 
     @Schema(description = "Number of columns in the grid")
     private int columns;
+
+    @Schema(description = "Name of the grid, if set")
+    private String name;
 }

--- a/src/main/java/preponderous/viron/dto/UpdateGridNameRequest.java
+++ b/src/main/java/preponderous/viron/dto/UpdateGridNameRequest.java
@@ -1,0 +1,17 @@
+package preponderous.viron.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request body for updating a grid's name")
+public class UpdateGridNameRequest {
+    @NotBlank
+    @Schema(description = "New name for the grid")
+    private String name;
+}

--- a/src/main/java/preponderous/viron/models/Grid.java
+++ b/src/main/java/preponderous/viron/models/Grid.java
@@ -10,11 +10,13 @@ public class Grid {
     private int gridId;
     private int rows;
     private int columns;
+    private String name;
 
-    public Grid(int gridId, int rows, int columns) {
+    public Grid(int gridId, int rows, int columns, String name) {
         this.gridId = gridId;
         this.rows = rows;
         this.columns = columns;
+        this.name = name;
     }
 
     @Override
@@ -23,6 +25,7 @@ public class Grid {
                 "gridId=" + gridId +
                 ", rows=" + rows +
                 ", columns=" + columns +
+                ", name='" + name + '\'' +
                 '}';
     }
 }

--- a/src/main/java/preponderous/viron/repositories/GridRepository.java
+++ b/src/main/java/preponderous/viron/repositories/GridRepository.java
@@ -9,4 +9,5 @@ public interface GridRepository {
     Optional<Grid> findById(int id);
     List<Grid> findByEnvironmentId(int environmentId);
     Optional<Grid> findByEntityId(int entityId);
+    boolean updateName(int id, String name);
 }

--- a/src/main/java/preponderous/viron/repositories/GridRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/GridRepositoryImpl.java
@@ -21,7 +21,8 @@ public class GridRepositoryImpl implements GridRepository {
         int id = rs.getInt("grid_id");
         int rows = rs.getInt("rows");
         int columns = rs.getInt("columns");
-        return new Grid(id, rows, columns);
+        String name = rs.getString("name");
+        return new Grid(id, rows, columns, name);
     }
 
     @Override
@@ -47,5 +48,11 @@ public class GridRepositoryImpl implements GridRepository {
                 "(SELECT grid_id FROM viron.location_grid WHERE location_id in " +
                 "(SELECT location_id FROM viron.entity_location WHERE entity_id = ?))";
         return dbInteractions.queryOne(query, this::mapResultSetToGrid, entityId);
+    }
+
+    @Override
+    public boolean updateName(int id, String name) {
+        String query = "UPDATE viron.grid SET name = ? WHERE grid_id = ?";
+        return dbInteractions.update(query, name, id);
     }
 }

--- a/src/main/python/preponderous/viron/models/grid.py
+++ b/src/main/python/preponderous/viron/models/grid.py
@@ -2,10 +2,11 @@
 # MIT License
 
 class Grid:
-    def __init__(self, gridId: int, rows: int, columns: int):
+    def __init__(self, gridId: int, rows: int, columns: int, name: str = None):
         self.grid_id = gridId
         self.rows = rows
         self.columns = columns
+        self.name = name
 
     def get_grid_id(self) -> int:
         return self.grid_id
@@ -25,5 +26,11 @@ class Grid:
     def set_columns(self, columns: int):
         self.columns = columns
 
+    def get_name(self) -> str:
+        return self.name
+
+    def set_name(self, name: str):
+        self.name = name
+
     def __str__(self) -> str:
-        return f"Grid{{grid_id={self.grid_id}, rows={self.rows}, columns={self.columns}}}"
+        return f"Grid{{grid_id={self.grid_id}, rows={self.rows}, columns={self.columns}, name={self.name}}}"

--- a/src/main/python/preponderous/viron/services/gridService.py
+++ b/src/main/python/preponderous/viron/services/gridService.py
@@ -40,3 +40,8 @@ class GridService:
         response = requests.get(f"{self.get_base_url()}/entity/{entity_id}", headers=self.get_auth_headers())
         response.raise_for_status()
         return Grid(**response.json())
+
+    def update_grid_name(self, grid_id: int, name: str) -> bool:
+        response = requests.patch(f"{self.get_base_url()}/{grid_id}/name", json={"name": name}, headers=self.get_auth_headers())
+        response.raise_for_status()
+        return response.status_code == 200

--- a/src/test/java/preponderous/viron/controllers/DebugControllerTest.java
+++ b/src/test/java/preponderous/viron/controllers/DebugControllerTest.java
@@ -72,7 +72,7 @@ class DebugControllerTest {
     @Test
     void createSampleData_Success() throws Exception {
         Environment environment = new Environment(1, "Sample Environment", "2024-01-01");
-        Grid grid = new Grid(1, 10, 10);
+        Grid grid = new Grid(1, 10, 10, null);
         List<Location> locations = buildLocationGrid(10, 10);
 
         when(environmentService.createEnvironment("Sample Environment", 1, 10)).thenReturn(environment);
@@ -119,7 +119,7 @@ class DebugControllerTest {
     @Test
     void createWorldAndPlaceEntity_Success() throws Exception {
         Environment environment = new Environment(2, "TestWorld", "2024-02-01");
-        Grid grid = new Grid(5, 5, 5);
+        Grid grid = new Grid(5, 5, 5, null);
         List<Location> locations = buildLocationGrid(5, 5);
 
         when(environmentService.createEnvironment("TestWorld", 1, 5)).thenReturn(environment);
@@ -150,7 +150,7 @@ class DebugControllerTest {
     @Test
     void createWorldAndPlaceEntity_ServiceException_Returns500() throws Exception {
         Environment environment = new Environment(3, "FailWorld", "2024-03-01");
-        Grid grid = new Grid(6, 5, 5);
+        Grid grid = new Grid(6, 5, 5, null);
 
         when(environmentService.createEnvironment("FailWorld", 1, 5)).thenReturn(environment);
         when(gridService.getGridsInEnvironment(3)).thenReturn(List.of(grid));
@@ -178,7 +178,7 @@ class DebugControllerTest {
     @Test
     void createWorldAndPlaceEntity_NoValidLocation_Returns400() throws Exception {
         Environment environment = new Environment(4, "EmptyWorld", "2024-04-01");
-        Grid grid = new Grid(7, 5, 5);
+        Grid grid = new Grid(7, 5, 5, null);
 
         when(environmentService.createEnvironment("EmptyWorld", 1, 5)).thenReturn(environment);
         when(gridService.getGridsInEnvironment(4)).thenReturn(List.of(grid));

--- a/src/test/java/preponderous/viron/controllers/GridControllerTest.java
+++ b/src/test/java/preponderous/viron/controllers/GridControllerTest.java
@@ -3,6 +3,7 @@ package preponderous.viron.controllers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -50,12 +51,12 @@ class GridControllerTest {
     @Test
     void getAllGrids_Success() throws Exception {
         List<Grid> grids = List.of(
-                new Grid(1, 10, 20),
-                new Grid(2, 30, 40)
+                new Grid(1, 10, 20, null),
+                new Grid(2, 30, 40, null)
         );
         List<GridDto> dtos = List.of(
-                new GridDto(1, 10, 20),
-                new GridDto(2, 30, 40)
+                new GridDto(1, 10, 20, null),
+                new GridDto(2, 30, 40, null)
         );
         when(gridRepository.findAll()).thenReturn(grids);
         when(gridMapper.toDtoList(grids)).thenReturn(dtos);
@@ -88,8 +89,8 @@ class GridControllerTest {
 
     @Test
     void getGridById_Success() throws Exception {
-        Grid grid = new Grid(1, 10, 20);
-        GridDto dto = new GridDto(1, 10, 20);
+        Grid grid = new Grid(1, 10, 20, "battlefield");
+        GridDto dto = new GridDto(1, 10, 20, "battlefield");
         when(gridRepository.findById(1)).thenReturn(Optional.of(grid));
         when(gridMapper.toDto(grid)).thenReturn(dto);
 
@@ -97,7 +98,8 @@ class GridControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.gridId").value(1))
                 .andExpect(jsonPath("$.rows").value(10))
-                .andExpect(jsonPath("$.columns").value(20));
+                .andExpect(jsonPath("$.columns").value(20))
+                .andExpect(jsonPath("$.name").value("battlefield"));
 
         verify(gridRepository).findById(1);
         verify(gridMapper).toDto(grid);
@@ -127,8 +129,8 @@ class GridControllerTest {
 
     @Test
     void getGridsInEnvironment_Success() throws Exception {
-        List<Grid> grids = List.of(new Grid(1, 10, 20));
-        List<GridDto> dtos = List.of(new GridDto(1, 10, 20));
+        List<Grid> grids = List.of(new Grid(1, 10, 20, null));
+        List<GridDto> dtos = List.of(new GridDto(1, 10, 20, null));
         when(gridRepository.findByEnvironmentId(1)).thenReturn(grids);
         when(gridMapper.toDtoList(grids)).thenReturn(dtos);
 
@@ -167,8 +169,8 @@ class GridControllerTest {
 
     @Test
     void getGridOfEntity_Success() throws Exception {
-        Grid grid = new Grid(5, 15, 25);
-        GridDto dto = new GridDto(5, 15, 25);
+        Grid grid = new Grid(5, 15, 25, null);
+        GridDto dto = new GridDto(5, 15, 25, null);
         when(gridRepository.findByEntityId(1)).thenReturn(Optional.of(grid));
         when(gridMapper.toDto(grid)).thenReturn(dto);
 
@@ -200,5 +202,58 @@ class GridControllerTest {
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.status").value(500))
                 .andExpect(jsonPath("$.message").isString());
+    }
+
+    // --- PATCH /api/v1/grids/{id}/name ---
+
+    @Test
+    void updateGridName_Success() throws Exception {
+        when(gridRepository.findById(1)).thenReturn(Optional.of(new Grid(1, 10, 20, null)));
+        when(gridRepository.updateName(1, "NewName")).thenReturn(true);
+
+        mockMvc.perform(patch("/api/v1/grids/1/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"NewName\"}"))
+                .andExpect(status().isOk());
+
+        verify(gridRepository).updateName(1, "NewName");
+    }
+
+    @Test
+    void updateGridName_NotFound() throws Exception {
+        when(gridRepository.findById(1)).thenReturn(Optional.empty());
+
+        mockMvc.perform(patch("/api/v1/grids/1/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"NewName\"}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("Grid not found with id: 1"));
+
+        verify(gridRepository, never()).updateName(anyInt(), anyString());
+    }
+
+    @Test
+    void updateGridName_ThrowsException() throws Exception {
+        when(gridRepository.findById(1)).thenReturn(Optional.of(new Grid(1, 10, 20, null)));
+        when(gridRepository.updateName(1, "NewName")).thenThrow(new RuntimeException("Database error"));
+
+        mockMvc.perform(patch("/api/v1/grids/1/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"NewName\"}"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.message").isString());
+    }
+
+    @Test
+    void updateGridName_BlankName_ReturnsBadRequest() throws Exception {
+        mockMvc.perform(patch("/api/v1/grids/1/name")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+
+        verify(gridRepository, never()).updateName(anyInt(), anyString());
     }
 }

--- a/src/test/java/preponderous/viron/models/GridTest.java
+++ b/src/test/java/preponderous/viron/models/GridTest.java
@@ -12,27 +12,41 @@ public class GridTest {
 
     @Test
     void testInitialization() {
-        Grid grid = new Grid(0, 10, 10);
+        Grid grid = new Grid(0, 10, 10, null);
     }
 
     @Test
     void testGetId() {
-        Grid grid = new Grid(0, 10, 10);
+        Grid grid = new Grid(0, 10, 10, null);
         grid.setGridId(0);
         assertEquals(0, grid.getGridId());
     }
 
     @Test
     void testGetRows() {
-        Grid grid = new Grid(0, 10, 10);
+        Grid grid = new Grid(0, 10, 10, null);
         grid.setRows(10);
         assertEquals(10, grid.getRows());
     }
 
     @Test
     void testGetColumns() {
-        Grid grid = new Grid(0, 10, 10);
+        Grid grid = new Grid(0, 10, 10, null);
         grid.setColumns(10);
         assertEquals(10, grid.getColumns());
+    }
+
+    @Test
+    void testGetName_NullWhenConstructedWithoutName() {
+        Grid grid = new Grid(0, 10, 10, null);
+        assertEquals(null, grid.getName());
+    }
+
+    @Test
+    void testGetSetName() {
+        Grid grid = new Grid(0, 10, 10, "battlefield");
+        assertEquals("battlefield", grid.getName());
+        grid.setName("arena");
+        assertEquals("arena", grid.getName());
     }
 }

--- a/src/test/java/preponderous/viron/repositories/GridRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/GridRepositoryImplTest.java
@@ -35,6 +35,7 @@ public class GridRepositoryImplTest {
         Mockito.when(mockResultSet.getInt("grid_id")).thenReturn(1, 2);
         Mockito.when(mockResultSet.getInt("rows")).thenReturn(10, 20);
         Mockito.when(mockResultSet.getInt("columns")).thenReturn(5, 15);
+        Mockito.when(mockResultSet.getString("name")).thenReturn("battlefield", null);
 
         GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
 
@@ -44,9 +45,11 @@ public class GridRepositoryImplTest {
         assertThat(result.get(0).getGridId()).isEqualTo(1);
         assertThat(result.get(0).getRows()).isEqualTo(10);
         assertThat(result.get(0).getColumns()).isEqualTo(5);
+        assertThat(result.get(0).getName()).isEqualTo("battlefield");
         assertThat(result.get(1).getGridId()).isEqualTo(2);
         assertThat(result.get(1).getRows()).isEqualTo(20);
         assertThat(result.get(1).getColumns()).isEqualTo(15);
+        assertThat(result.get(1).getName()).isNull();
     }
 
     @Test
@@ -79,6 +82,7 @@ public class GridRepositoryImplTest {
         Mockito.when(mockResultSet.getInt("grid_id")).thenReturn(1);
         Mockito.when(mockResultSet.getInt("rows")).thenReturn(10);
         Mockito.when(mockResultSet.getInt("columns")).thenReturn(5);
+        Mockito.when(mockResultSet.getString("name")).thenReturn("battlefield");
 
         GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
 
@@ -88,6 +92,7 @@ public class GridRepositoryImplTest {
         assertThat(result.get().getGridId()).isEqualTo(1);
         assertThat(result.get().getRows()).isEqualTo(10);
         assertThat(result.get().getColumns()).isEqualTo(5);
+        assertThat(result.get().getName()).isEqualTo("battlefield");
     }
 
     @Test
@@ -174,5 +179,27 @@ public class GridRepositoryImplTest {
         GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
 
         assertThat(repository.findByEntityId(42)).isEmpty();
+    }
+
+    // ---- updateName ----
+
+    @Test
+    public void testUpdateName_ReturnsTrueWhenUpdateSucceeds() {
+        String query = "UPDATE viron.grid SET name = ? WHERE grid_id = ?";
+        Mockito.when(dbInteractions.update(query, "arena", 1)).thenReturn(true);
+
+        GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
+
+        assertThat(repository.updateName(1, "arena")).isTrue();
+    }
+
+    @Test
+    public void testUpdateName_ReturnsFalseWhenUpdateFails() {
+        String query = "UPDATE viron.grid SET name = ? WHERE grid_id = ?";
+        Mockito.when(dbInteractions.update(query, "arena", 1)).thenReturn(false);
+
+        GridRepositoryImpl repository = new GridRepositoryImpl(dbInteractions);
+
+        assertThat(repository.updateName(1, "arena")).isFalse();
     }
 }

--- a/src/test/python/preponderous/viron/models/test_grid.py
+++ b/src/test/python/preponderous/viron/models/test_grid.py
@@ -22,5 +22,14 @@ def test_get_set_columns(grid):
     grid.set_columns(25)
     assert grid.get_columns() == 25
 
+def test_name_defaults_to_none(grid):
+    assert grid.get_name() is None
+
+def test_get_set_name():
+    grid = Grid(1, 10, 20, "battlefield")
+    assert grid.get_name() == "battlefield"
+    grid.set_name("arena")
+    assert grid.get_name() == "arena"
+
 def test_str_representation(grid):
-    assert str(grid) == "Grid{grid_id=1, rows=10, columns=20}"
+    assert str(grid) == "Grid{grid_id=1, rows=10, columns=20, name=None}"

--- a/src/test/python/preponderous/viron/services/test_gridService.py
+++ b/src/test/python/preponderous/viron/services/test_gridService.py
@@ -58,7 +58,7 @@ class TestGetAllGrids:
 class TestGetGridById:
     @patch('requests.get')
     def test_success(self, mock_get, mock_response):
-        mock_response.json.return_value = {'gridId': 1, 'rows': 10, 'columns': 20}
+        mock_response.json.return_value = {'gridId': 1, 'rows': 10, 'columns': 20, 'name': 'battlefield'}
         mock_get.return_value = mock_response
 
         grid = service.get_grid_by_id(1)
@@ -67,6 +67,7 @@ class TestGetGridById:
         assert grid.get_grid_id() == 1
         assert grid.get_rows() == 10
         assert grid.get_columns() == 20
+        assert grid.get_name() == 'battlefield'
         mock_get.assert_called_once_with(f"{BASE_URL}{API_PATH}/1", headers={})
 
     @patch('requests.get')
@@ -173,4 +174,30 @@ class TestGetGridOfEntity:
 
         with pytest.raises(Exception) as exc_info:
             service.get_grid_of_entity(1)
+        assert str(exc_info.value) == "Test error"
+
+
+class TestUpdateGridName:
+    @patch('requests.patch')
+    def test_success(self, mock_patch):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = Mock()
+        mock_patch.return_value = mock_response
+
+        result = service.update_grid_name(1, "NewName")
+
+        assert result is True
+        mock_patch.assert_called_once_with(
+            f"{BASE_URL}{API_PATH}/1/name",
+            json={"name": "NewName"},
+            headers={},
+        )
+
+    @patch('requests.patch')
+    def test_error(self, mock_patch):
+        mock_patch.side_effect = Exception("Test error")
+
+        with pytest.raises(Exception) as exc_info:
+            service.update_grid_name(1, "NewName")
         assert str(exc_info.value) == "Test error"


### PR DESCRIPTION
## Summary
- RFC 0001 says Viron should define grids "with metadata", but `Grid` previously stored only `gridId`/`rows`/`columns`.
- Adds an optional `name` field to `Grid`/`GridDto` (nullable, mirrored in the Python client's `Grid` model) so a game can distinguish/label grids without external bookkeeping.
- Adds `PATCH /api/v1/grids/{id}/name` (repository `updateName`, `UpdateGridNameRequest` DTO, Python `update_grid_name`) to set it, mirroring the existing `Environment`/`Entity` name-update pattern — there was previously no way to set it via the API.
- Updates `docs/openapi/viron-api.json`, `docs/MVP.md`, and the Postman collection to reflect the new field and endpoint.
- Adds a nullable `name VARCHAR(255)` column to `viron.grid` in `create_tables.sql` (no migration framework in this repo — it's the single schema source of truth, per existing convention).

Scoped down from the issue's full "name + tags/properties" suggestion to just `name` to stay within a single-cycle scope; broader structured metadata (tags, arbitrary properties) is left for a follow-up if wanted.

## Test plan
- [x] `mvn test -B` — 264/264 Java tests pass (build pinned to JDK 21 via this sandbox's `~/.mavenrc`; project requires `java.version=21`)
- [x] `python3 -m pytest src/test/python/preponderous/viron/models/test_grid.py src/test/python/preponderous/viron/services/test_gridService.py -q` — 24/24 pass
- [ ] **Note:** the full Python suite (`pytest` at repo root) cannot be collected in this sandbox — `python3` here is 3.8, and an unrelated pre-existing file (`environmentService.py`, not touched by this PR) uses `list[Environment]` (PEP 585, requires 3.9+). This is a sandbox/environment limitation, not something introduced by this PR — the grid-scoped run above (which exercises everything this PR changes) passes cleanly. The project's CI workflow also does not execute the Python client at all (`./mvnw` only), so this gap pre-dates and is orthogonal to this change. Recommend a real Python 3.9+ run of the full suite before merge as a sanity check.

Closes #148

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
