### PR TITLE
docs: fix stale environment endpoint shapes in tickets.md

### DIFF
--- a/tickets.md
+++ b/tickets.md
@@ -83,8 +83,8 @@ Each ticket is designed to:
   - `GET /api/v1/environments/{id}`
   - `GET /api/v1/environments/name/{name}`
   - `GET /api/v1/environments/entity/{entityId}`
-  - `POST /api/v1/environments/{name}/{numGrids}/{gridSize}`
-  - `PATCH /api/v1/environments/{id}/name/{name}`
+  - `POST /api/v1/environments` — JSON body: `name`, `numGrids`, and grid dimensions as either `gridSize` or both `numRows` and `numColumns`
+  - `PATCH /api/v1/environments/{id}/name` — JSON body: `name`
   - `DELETE /api/v1/environments/{id}`
 - Add exception handling and proper HTTP status codes
 - Write controller tests (@WebMvcTest or @SpringBootTest)


### PR DESCRIPTION
## Summary
- Stage A documentation accuracy sweep (thin backlog cycle — the only open issue, #130, is a larger architectural devexp change already deferred twice for exceeding single-cycle scope; deferring again this cycle for the same reason).
- Full sweep of `docs/openapi/viron-api.json` against the controllers (Environment/Grid/Location/Entity/Debug), `docs/MVP.md`, `docs/PLANNING.md`, `docs/REBUILD_PLAN.md`, `tickets.md`, `README.md`, and the Postman collection found the spec, controllers, DTOs, MVP checklist, and Postman collection all in agreement — no drift there.
- Found one real drift: `tickets.md` Ticket 3 documented `POST /api/v1/environments/{name}/{numGrids}/{gridSize}` and `PATCH /api/v1/environments/{id}/name/{name}` as the environment create/rename endpoint shapes. The actual implementation (and `docs/openapi/viron-api.json`) has always taken these as JSON request bodies (`POST /api/v1/environments` with a `CreateEnvironmentRequest` body; `PATCH /api/v1/environments/{id}/name` with an `UpdateEnvironmentNameRequest` body) — confirmed this was present since the file's introduction via `git log --follow`, i.e. a doc bug rather than a recent regression. Corrected the ticket text to match the real contract.

## Test plan
- [x] Docs-only change; no code paths touched.
- [x] Verified `docs/openapi/viron-api.json`, `EnvironmentController.java`, `CreateEnvironmentRequest.java`, and `UpdateEnvironmentNameRequest.java` all agree on the corrected shapes.

No tracking issue — gap found during this cycle's documentation sweep.

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
