### PR TITLE
test: add CI guard for OpenAPI spec/controller route drift

### DIFF
--- a/src/test/java/preponderous/viron/OpenApiSpecDriftTest.java
+++ b/src/test/java/preponderous/viron/OpenApiSpecDriftTest.java
@@ -1,0 +1,73 @@
+// Copyright (c) 2024 Preponderous Software
+// MIT License
+
+package preponderous.viron;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.File;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Spec-drift guard (issue #130): fails the build if the controllers' live routes
+ * (as reported by springdoc at {@code /v3/api-docs}) diverge from the checked-in
+ * contract at {@code docs/openapi/viron-api.json}. Enables the debug endpoints so
+ * {@link preponderous.viron.controllers.DebugController}'s routes are included, since
+ * they are part of the static spec too.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@WithMockUser
+@DirtiesContext
+@TestPropertySource(properties = "viron.debug.enabled=true")
+class OpenApiSpecDriftTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void liveRoutesMatchStaticSpec() throws Exception {
+        String liveJson = mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode liveSpec = mapper.readTree(liveJson);
+        JsonNode staticSpec = mapper.readTree(new File("docs/openapi/viron-api.json"));
+
+        Set<String> liveRoutes = extractRoutes(liveSpec);
+        Set<String> staticRoutes = extractRoutes(staticSpec);
+
+        assertEquals(staticRoutes, liveRoutes,
+                "docs/openapi/viron-api.json has drifted from the controllers' actual routes. "
+                        + "Update the spec (or the controller) so both agree.");
+    }
+
+    private Set<String> extractRoutes(JsonNode spec) {
+        Set<String> routes = new TreeSet<>();
+        Iterator<Map.Entry<String, JsonNode>> paths = spec.get("paths").fields();
+        while (paths.hasNext()) {
+            Map.Entry<String, JsonNode> pathEntry = paths.next();
+            String path = pathEntry.getKey();
+            pathEntry.getValue().fieldNames()
+                    .forEachRemaining(verb -> routes.add(verb.toUpperCase() + " " + path));
+        }
+        return routes;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `OpenApiSpecDriftTest`, a full-context Spring Boot test that fetches the live route list from springdoc's `/v3/api-docs` (with `viron.debug.enabled=true` so `DebugController`'s routes are included) and asserts it matches the route set (verb + path) declared in `docs/openapi/viron-api.json`.
- Because this runs under the existing `mvn test` step, CI now fails automatically if a controller's routes drift from the checked-in OpenAPI contract — no separate CI workflow step was needed.
- This addresses the **CI spec-drift guard** half of #130. The other half of that issue (wiring `openapi-generator-maven-plugin` for codegen, or generating the spec from code) is a materially larger, separate architectural change and is left open on #130 — this PR does not claim to close it.

## Verification
- Confirmed the guard actually detects drift: temporarily removed `POST /api/v1/environments` from the static spec and re-ran the test — it failed with a clear diff of the mismatched route sets. Reverted before committing.
- Confirmed it passes against the current (non-drifted) spec and controllers.

## Test plan
- [x] `mvn test -B` — full suite green (265 tests, 0 failures)
- [x] `mvn test -B -Dtest=OpenApiSpecDriftTest` — passes against current spec
- [x] Manually broke the static spec and confirmed the test fails with a useful message, then reverted

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
