### PR TITLE
test: add unit tests for EnvironmentFactory

### DIFF
--- a/src/test/java/preponderous/viron/factories/EnvironmentFactoryTest.java
+++ b/src/test/java/preponderous/viron/factories/EnvironmentFactoryTest.java
@@ -1,0 +1,180 @@
+package preponderous.viron.factories;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import preponderous.viron.database.DbInteractions;
+import preponderous.viron.exceptions.EnvironmentCreationException;
+import preponderous.viron.models.Environment;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+public class EnvironmentFactoryTest {
+
+    private static final String NEXT_ENVIRONMENT_ID_QUERY = "SELECT nextval('viron.environment_id_seq')";
+    private static final String NEXT_GRID_ID_QUERY = "SELECT nextval('viron.grid_id_seq')";
+    private static final String NEXT_LOCATION_ID_QUERY = "SELECT nextval('viron.location_id_seq')";
+
+    private static final String ENVIRONMENT_INSERT = "INSERT INTO viron.environment (environment_id, name, creation_date) VALUES (?, ?, ?)";
+    private static final String GRID_INSERT = "INSERT INTO viron.grid (grid_id, rows, columns) VALUES (?, ?, ?)";
+    private static final String GRID_ENVIRONMENT_ASSOCIATION_INSERT = "INSERT INTO viron.grid_environment (grid_id, environment_id) VALUES (?, ?)";
+    private static final String LOCATION_INSERT = "INSERT INTO viron.location (location_id, x, y) VALUES (?, ?, ?)";
+    private static final String LOCATION_GRID_ASSOCIATION_INSERT = "INSERT INTO viron.location_grid (location_id, grid_id) VALUES (?, ?)";
+
+    @MockBean
+    private DbInteractions dbInteractions;
+
+    private void stubHappyPathUpTo(String... queriesToSucceed) {
+        for (String query : queriesToSucceed) {
+            Mockito.when(dbInteractions.update(eq(query), any(), any(), any())).thenReturn(true);
+            Mockito.when(dbInteractions.update(eq(query), any(), any())).thenReturn(true);
+        }
+    }
+
+    @Test
+    public void testCreateEnvironment_Success_ReturnsEnvironment() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ENVIRONMENT_ID_QUERY), any())).thenReturn(Optional.of(10));
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_GRID_ID_QUERY), any())).thenReturn(Optional.of(20));
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_LOCATION_ID_QUERY), any())).thenReturn(Optional.of(30));
+        stubHappyPathUpTo(ENVIRONMENT_INSERT, GRID_INSERT, GRID_ENVIRONMENT_ASSOCIATION_INSERT, LOCATION_INSERT, LOCATION_GRID_ASSOCIATION_INSERT);
+
+        EnvironmentFactory factory = new EnvironmentFactory(dbInteractions);
+
+        Environment result = factory.createEnvironment("TestEnv", 1, 1, 1);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getEnvironmentId()).isEqualTo(10);
+        assertThat(result.getName()).isEqualTo("TestEnv");
+        assertThat(result.getCreationDate()).isNotNull();
+
+        verify(dbInteractions).update(eq(ENVIRONMENT_INSERT), eq(10), eq("TestEnv"), any());
+        verify(dbInteractions).update(eq(GRID_INSERT), eq(20), eq(1), eq(1));
+        verify(dbInteractions).update(eq(GRID_ENVIRONMENT_ASSOCIATION_INSERT), eq(20), eq(10));
+        verify(dbInteractions).update(eq(LOCATION_INSERT), eq(30), eq(0), eq(0));
+        verify(dbInteractions).update(eq(LOCATION_GRID_ASSOCIATION_INSERT), eq(30), eq(20));
+    }
+
+    @Test
+    public void testCreateEnvironment_NextEnvironmentIdUnavailable_ThrowsAndDoesNotInsert() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ENVIRONMENT_ID_QUERY), any())).thenReturn(Optional.empty());
+
+        EnvironmentFactory factory = new EnvironmentFactory(dbInteractions);
+
+        assertThatThrownBy(() -> factory.createEnvironment("TestEnv", 1, 1, 1))
+                .isInstanceOf(EnvironmentCreationException.class)
+                .hasMessage("Failed to get next environment id");
+        verify(dbInteractions, never()).update(eq(ENVIRONMENT_INSERT), any(), any(), any());
+    }
+
+    @Test
+    public void testCreateEnvironment_EnvironmentInsertFails_Throws() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ENVIRONMENT_ID_QUERY), any())).thenReturn(Optional.of(10));
+        Mockito.when(dbInteractions.update(eq(ENVIRONMENT_INSERT), any(), any(), any())).thenReturn(false);
+
+        EnvironmentFactory factory = new EnvironmentFactory(dbInteractions);
+
+        assertThatThrownBy(() -> factory.createEnvironment("TestEnv", 1, 1, 1))
+                .isInstanceOf(EnvironmentCreationException.class)
+                .hasMessage("Failed to create environment");
+        verify(dbInteractions, never()).update(eq(GRID_INSERT), any(), any(), any());
+    }
+
+    @Test
+    public void testCreateEnvironment_NextGridIdUnavailable_ThrowsAndDoesNotInsertGrid() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ENVIRONMENT_ID_QUERY), any())).thenReturn(Optional.of(10));
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_GRID_ID_QUERY), any())).thenReturn(Optional.empty());
+        stubHappyPathUpTo(ENVIRONMENT_INSERT);
+
+        EnvironmentFactory factory = new EnvironmentFactory(dbInteractions);
+
+        assertThatThrownBy(() -> factory.createEnvironment("TestEnv", 1, 1, 1))
+                .isInstanceOf(EnvironmentCreationException.class)
+                .hasMessage("Failed to get next grid id");
+        verify(dbInteractions, never()).update(eq(GRID_INSERT), any(), any(), any());
+    }
+
+    @Test
+    public void testCreateEnvironment_GridInsertFails_Throws() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ENVIRONMENT_ID_QUERY), any())).thenReturn(Optional.of(10));
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_GRID_ID_QUERY), any())).thenReturn(Optional.of(20));
+        stubHappyPathUpTo(ENVIRONMENT_INSERT);
+        Mockito.when(dbInteractions.update(eq(GRID_INSERT), any(), any(), any())).thenReturn(false);
+
+        EnvironmentFactory factory = new EnvironmentFactory(dbInteractions);
+
+        assertThatThrownBy(() -> factory.createEnvironment("TestEnv", 1, 1, 1))
+                .isInstanceOf(EnvironmentCreationException.class)
+                .hasMessage("Failed to create grid");
+        verify(dbInteractions, never()).update(eq(GRID_ENVIRONMENT_ASSOCIATION_INSERT), any(), any());
+    }
+
+    @Test
+    public void testCreateEnvironment_GridEnvironmentAssociationFails_Throws() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ENVIRONMENT_ID_QUERY), any())).thenReturn(Optional.of(10));
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_GRID_ID_QUERY), any())).thenReturn(Optional.of(20));
+        stubHappyPathUpTo(ENVIRONMENT_INSERT, GRID_INSERT);
+        Mockito.when(dbInteractions.update(eq(GRID_ENVIRONMENT_ASSOCIATION_INSERT), any(), any())).thenReturn(false);
+
+        EnvironmentFactory factory = new EnvironmentFactory(dbInteractions);
+
+        assertThatThrownBy(() -> factory.createEnvironment("TestEnv", 1, 1, 1))
+                .isInstanceOf(EnvironmentCreationException.class)
+                .hasMessage("Failed to associate grid with environment");
+        verify(dbInteractions, never()).update(eq(LOCATION_INSERT), any(), any(), any());
+    }
+
+    @Test
+    public void testCreateEnvironment_NextLocationIdUnavailable_ThrowsAndDoesNotInsertLocation() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ENVIRONMENT_ID_QUERY), any())).thenReturn(Optional.of(10));
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_GRID_ID_QUERY), any())).thenReturn(Optional.of(20));
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_LOCATION_ID_QUERY), any())).thenReturn(Optional.empty());
+        stubHappyPathUpTo(ENVIRONMENT_INSERT, GRID_INSERT, GRID_ENVIRONMENT_ASSOCIATION_INSERT);
+
+        EnvironmentFactory factory = new EnvironmentFactory(dbInteractions);
+
+        assertThatThrownBy(() -> factory.createEnvironment("TestEnv", 1, 1, 1))
+                .isInstanceOf(EnvironmentCreationException.class)
+                .hasMessage("Failed to get next location id");
+        verify(dbInteractions, never()).update(eq(LOCATION_INSERT), any(), any(), any());
+    }
+
+    @Test
+    public void testCreateEnvironment_LocationInsertFails_Throws() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ENVIRONMENT_ID_QUERY), any())).thenReturn(Optional.of(10));
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_GRID_ID_QUERY), any())).thenReturn(Optional.of(20));
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_LOCATION_ID_QUERY), any())).thenReturn(Optional.of(30));
+        stubHappyPathUpTo(ENVIRONMENT_INSERT, GRID_INSERT, GRID_ENVIRONMENT_ASSOCIATION_INSERT);
+        Mockito.when(dbInteractions.update(eq(LOCATION_INSERT), any(), any(), any())).thenReturn(false);
+
+        EnvironmentFactory factory = new EnvironmentFactory(dbInteractions);
+
+        assertThatThrownBy(() -> factory.createEnvironment("TestEnv", 1, 1, 1))
+                .isInstanceOf(EnvironmentCreationException.class)
+                .hasMessage("Failed to create location");
+        verify(dbInteractions, never()).update(eq(LOCATION_GRID_ASSOCIATION_INSERT), any(), any());
+    }
+
+    @Test
+    public void testCreateEnvironment_LocationGridAssociationFails_Throws() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_ENVIRONMENT_ID_QUERY), any())).thenReturn(Optional.of(10));
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_GRID_ID_QUERY), any())).thenReturn(Optional.of(20));
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(NEXT_LOCATION_ID_QUERY), any())).thenReturn(Optional.of(30));
+        stubHappyPathUpTo(ENVIRONMENT_INSERT, GRID_INSERT, GRID_ENVIRONMENT_ASSOCIATION_INSERT, LOCATION_INSERT);
+        Mockito.when(dbInteractions.update(eq(LOCATION_GRID_ASSOCIATION_INSERT), any(), any())).thenReturn(false);
+
+        EnvironmentFactory factory = new EnvironmentFactory(dbInteractions);
+
+        assertThatThrownBy(() -> factory.createEnvironment("TestEnv", 1, 1, 1))
+                .isInstanceOf(EnvironmentCreationException.class)
+                .hasMessage("Failed to associate location with grid");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `EnvironmentFactoryTest`, mirroring the existing `EntityFactoryTest` pattern, covering `EnvironmentFactory.createEnvironment`'s success path and every failure branch (id-generation failures and insert failures across environment/grid/location creation and their associations).
- This code was previously untested: `EnvironmentControllerTest` mocks `EnvironmentFactory` entirely via `@MockBean`, so none of its internal logic (multi-step DB interaction sequencing, early-exit on each failure) was exercised anywhere in the suite.

## Work-selection note
Issue #130 (openapi-generator codegen wiring) is the only other open issue; its own linked PR (#179) explicitly scoped it out as "a materially larger, separate architectural change" (regenerating hand-written DTOs used throughout the codebase). This cycle deferred it again for the same reason and instead used Stage B (unit-test expansion) from the dev-loop skill to close a coverage gap found during triage.

## Test plan
- [x] `mvn test -B -Dtest=EnvironmentFactoryTest` — 9/9 new tests pass
- [x] `mvn test -B` — full suite green (274 tests, 0 failures)
- [x] No production code changed — pure test addition

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
