### PR TITLE
feat: add EnvironmentService tests and align its error handling

### DIFF
--- a/src/main/java/preponderous/viron/services/EnvironmentService.java
+++ b/src/main/java/preponderous/viron/services/EnvironmentService.java
@@ -4,24 +4,30 @@
 package preponderous.viron.services;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import lombok.extern.slf4j.Slf4j;
 import preponderous.viron.config.AuthTokenInterceptor;
 import preponderous.viron.config.ServiceConfig;
 import preponderous.viron.dto.CreateEnvironmentRequest;
 import preponderous.viron.dto.UpdateEnvironmentNameRequest;
+import preponderous.viron.exceptions.NotFoundException;
 import preponderous.viron.exceptions.ServiceException;
 import preponderous.viron.models.Environment;
 
 @Service
+@Slf4j
 public class EnvironmentService {
     private final RestTemplateBuilder restTemplateBuilder;
     private final ServiceConfig serviceConfig;
@@ -35,39 +41,70 @@ public class EnvironmentService {
     }
 
     public List<Environment> getAllEnvironments() {
-        RestTemplate restTemplate = restTemplateBuilder.build();
-        ResponseEntity<Environment[]> response = restTemplate.exchange(baseUrl, HttpMethod.GET, null, Environment[].class);
-        if (response.getStatusCode().isError()) {
-            throw new ServiceException("Error getting environments");
+        try {
+            RestTemplate restTemplate = restTemplateBuilder.build();
+            ResponseEntity<Environment[]> response = restTemplate.exchange(baseUrl, HttpMethod.GET, null, Environment[].class);
+            return response.getStatusCode() == HttpStatus.OK && response.getBody() != null
+                    ? Arrays.asList(response.getBody())
+                    : Collections.emptyList();
+        } catch (Exception e) {
+            log.error("Error getting environments: {}", e.getMessage());
+            throw new ServiceException("Error getting environments", e);
         }
-        return Arrays.asList(response.getBody());
     }
 
     public Environment getEnvironmentById(int id) {
-        RestTemplate restTemplate = restTemplateBuilder.build();
-        ResponseEntity<Environment> response = restTemplate.exchange(baseUrl + "/{id}", HttpMethod.GET, null, Environment.class, id);
-        if (response.getStatusCode().isError()) {
-            throw new ServiceException("Error getting environment by id");
+        try {
+            RestTemplate restTemplate = restTemplateBuilder.build();
+            ResponseEntity<Environment> response = restTemplate.exchange(baseUrl + "/{id}", HttpMethod.GET, null, Environment.class, id);
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                return response.getBody();
+            }
+            throw new NotFoundException("Environment not found with id: " + id);
+        } catch (HttpClientErrorException.NotFound e) {
+            throw new NotFoundException("Environment not found with id: " + id);
+        } catch (ServiceException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Error getting environment by id {}: {}", id, e.getMessage());
+            throw new ServiceException("Error getting environment by id: " + id, e);
         }
-        return response.getBody();
     }
 
     public Environment getEnvironmentByName(String name) {
-        RestTemplate restTemplate = restTemplateBuilder.build();
-        ResponseEntity<Environment> response = restTemplate.exchange(baseUrl + "/name/{name}", HttpMethod.GET, null, Environment.class, name);
-        if (response.getStatusCode().isError()) {
-            throw new ServiceException("Error getting environment by name");
+        try {
+            RestTemplate restTemplate = restTemplateBuilder.build();
+            ResponseEntity<Environment> response = restTemplate.exchange(baseUrl + "/name/{name}", HttpMethod.GET, null, Environment.class, name);
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                return response.getBody();
+            }
+            throw new NotFoundException("Environment not found with name: " + name);
+        } catch (HttpClientErrorException.NotFound e) {
+            throw new NotFoundException("Environment not found with name: " + name);
+        } catch (ServiceException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Error getting environment by name {}: {}", name, e.getMessage());
+            throw new ServiceException("Error getting environment by name: " + name, e);
         }
-        return response.getBody();
     }
 
     public Environment getEnvironmentOfEntity(int entityId) {
-        RestTemplate restTemplate = restTemplateBuilder.build();
-        ResponseEntity<Environment> response = restTemplate.exchange(baseUrl + "/entity/{entityId}", HttpMethod.GET, null, Environment.class, entityId);
-        if (response.getStatusCode().isError()) {
-            throw new ServiceException("Error getting environment of entity");
+        try {
+            RestTemplate restTemplate = restTemplateBuilder.build();
+            ResponseEntity<Environment> response = restTemplate.exchange(baseUrl + "/entity/{entityId}", HttpMethod.GET, null, Environment.class, entityId);
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                return response.getBody();
+            }
+            throw new NotFoundException("Environment not found for entity: " + entityId);
+        } catch (HttpClientErrorException.NotFound e) {
+            throw new NotFoundException("Environment not found for entity: " + entityId);
+        } catch (ServiceException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Error getting environment of entity {}: {}", entityId, e.getMessage());
+            throw new ServiceException("Error getting environment of entity: " + entityId, e);
         }
-        return response.getBody();
     }
 
     /**
@@ -90,40 +127,71 @@ public class EnvironmentService {
     }
 
     private Environment createEnvironment(CreateEnvironmentRequest request) {
-        RestTemplate restTemplate = restTemplateBuilder.build();
-        ResponseEntity<Environment> response = restTemplate.exchange(
-                baseUrl,
-                HttpMethod.POST,
-                new HttpEntity<>(request),
-                Environment.class
-        );
-        if (response.getStatusCode().isError()) {
+        try {
+            RestTemplate restTemplate = restTemplateBuilder.build();
+            ResponseEntity<Environment> response = restTemplate.exchange(
+                    baseUrl,
+                    HttpMethod.POST,
+                    new HttpEntity<>(request),
+                    Environment.class
+            );
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                return response.getBody();
+            }
             throw new ServiceException("Error creating environment");
+        } catch (ServiceException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Error creating environment {}: {}", request.getName(), e.getMessage());
+            throw new ServiceException("Error creating environment", e);
         }
-        return response.getBody();
     }
 
     public boolean deleteEnvironment(int id) {
-        RestTemplate restTemplate = restTemplateBuilder.build();
-        ResponseEntity<Void> response = restTemplate.exchange(baseUrl + "/{id}", HttpMethod.DELETE, null, Void.class, id);
-        if (response.getStatusCode().isError()) {
-            throw new ServiceException("Error deleting environment");
+        try {
+            RestTemplate restTemplate = restTemplateBuilder.build();
+            ResponseEntity<Void> response = restTemplate.exchange(baseUrl + "/{id}", HttpMethod.DELETE, null, Void.class, id);
+            if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
+                throw new NotFoundException("Environment not found with id: " + id);
+            }
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new ServiceException("Error deleting environment");
+            }
+            return true;
+        } catch (HttpClientErrorException.NotFound e) {
+            throw new NotFoundException("Environment not found with id: " + id);
+        } catch (ServiceException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Error deleting environment {}: {}", id, e.getMessage());
+            throw new ServiceException("Error deleting environment", e);
         }
-        return response.getStatusCode().is2xxSuccessful();
     }
 
     public boolean updateEnvironmentName(int id, String name) {
-        RestTemplate restTemplate = restTemplateBuilder.build();
-        ResponseEntity<Void> response = restTemplate.exchange(
-                baseUrl + "/{id}/name",
-                HttpMethod.PATCH,
-                new HttpEntity<>(new UpdateEnvironmentNameRequest(name)),
-                Void.class,
-                id
-        );
-        if (response.getStatusCode().isError()) {
-            throw new ServiceException("Error updating environment name");
+        try {
+            RestTemplate restTemplate = restTemplateBuilder.build();
+            ResponseEntity<Void> response = restTemplate.exchange(
+                    baseUrl + "/{id}/name",
+                    HttpMethod.PATCH,
+                    new HttpEntity<>(new UpdateEnvironmentNameRequest(name)),
+                    Void.class,
+                    id
+            );
+            if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
+                throw new NotFoundException("Environment not found with id: " + id);
+            }
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new ServiceException("Error updating environment name");
+            }
+            return true;
+        } catch (HttpClientErrorException.NotFound e) {
+            throw new NotFoundException("Environment not found with id: " + id);
+        } catch (ServiceException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Error updating name for environment {}: {}", id, e.getMessage());
+            throw new ServiceException("Error updating environment name", e);
         }
-        return response.getStatusCode().is2xxSuccessful();
     }
 }

--- a/src/test/java/preponderous/viron/services/EnvironmentServiceTest.java
+++ b/src/test/java/preponderous/viron/services/EnvironmentServiceTest.java
@@ -1,0 +1,425 @@
+package preponderous.viron.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import preponderous.viron.config.ServiceConfig;
+import preponderous.viron.dto.CreateEnvironmentRequest;
+import preponderous.viron.dto.UpdateEnvironmentNameRequest;
+import preponderous.viron.exceptions.NotFoundException;
+import preponderous.viron.exceptions.ServiceException;
+import preponderous.viron.models.Environment;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+public class EnvironmentServiceTest {
+
+    private static final String BASE_URL = "http://localhost:8080/api/v1/environments";
+    private static final String BY_ID_URL = BASE_URL + "/{id}";
+    private static final String BY_NAME_URL = BASE_URL + "/name/{name}";
+    private static final String OF_ENTITY_URL = BASE_URL + "/entity/{entityId}";
+    private static final String NAME_URL = BASE_URL + "/{id}/name";
+
+    private RestTemplate restTemplate;
+    private EnvironmentService environmentService;
+
+    @BeforeEach
+    void setUp() {
+        RestTemplateBuilder restTemplateBuilder = Mockito.mock(RestTemplateBuilder.class);
+        restTemplate = Mockito.mock(RestTemplate.class);
+        Mockito.when(restTemplateBuilder.additionalInterceptors(any(ClientHttpRequestInterceptor.class)))
+                .thenReturn(restTemplateBuilder);
+        Mockito.when(restTemplateBuilder.build()).thenReturn(restTemplate);
+
+        ServiceConfig serviceConfig = new ServiceConfig();
+        serviceConfig.setVironHost("http://localhost");
+        serviceConfig.setVironPort(8080);
+
+        environmentService = new EnvironmentService(restTemplateBuilder, serviceConfig);
+    }
+
+    private static HttpEntity<Void> nullRequestEntity() {
+        return ArgumentMatchers.isNull();
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static ArgumentCaptor<HttpEntity> requestEntityCaptor() {
+        return ArgumentCaptor.forClass(HttpEntity.class);
+    }
+
+    // getAllEnvironments
+
+    @Test
+    void testGetAllEnvironments_Success_ReturnsEnvironments() {
+        Environment[] environments = {
+                new Environment(1, "Env1", "2024-01-01"),
+                new Environment(2, "Env2", "2024-01-02")
+        };
+        Mockito.when(restTemplate.exchange(
+                        eq(BASE_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment[].class)))
+                .thenReturn(ResponseEntity.ok(environments));
+
+        List<Environment> result = environmentService.getAllEnvironments();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getName()).isEqualTo("Env1");
+    }
+
+    @Test
+    void testGetAllEnvironments_NullBody_ReturnsEmptyList() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BASE_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment[].class)))
+                .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
+
+        assertThat(environmentService.getAllEnvironments()).isEmpty();
+    }
+
+    @Test
+    void testGetAllEnvironments_NonOkStatus_ReturnsEmptyList() {
+        Environment[] environments = {new Environment(1, "Env1", "2024-01-01")};
+        Mockito.when(restTemplate.exchange(
+                        eq(BASE_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment[].class)))
+                .thenReturn(new ResponseEntity<>(environments, HttpStatus.NO_CONTENT));
+
+        assertThat(environmentService.getAllEnvironments()).isEmpty();
+    }
+
+    @Test
+    void testGetAllEnvironments_RestTemplateThrows_WrapsInServiceException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BASE_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment[].class)))
+                .thenThrow(new RestClientException("boom"));
+
+        assertThatThrownBy(() -> environmentService.getAllEnvironments())
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Error getting environments");
+    }
+
+    // getEnvironmentById
+
+    @Test
+    void testGetEnvironmentById_Success_ReturnsEnvironment() {
+        Environment environment = new Environment(1, "Env1", "2024-01-01");
+        Mockito.when(restTemplate.exchange(
+                        eq(BY_ID_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment.class), eq(1)))
+                .thenReturn(ResponseEntity.ok(environment));
+
+        assertThat(environmentService.getEnvironmentById(1)).isEqualTo(environment);
+    }
+
+    @Test
+    void testGetEnvironmentById_NullBody_ThrowsNotFoundException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BY_ID_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment.class), eq(1)))
+                .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
+
+        assertThatThrownBy(() -> environmentService.getEnvironmentById(1))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Environment not found with id: 1");
+    }
+
+    @Test
+    void testGetEnvironmentById_NotFoundResponse_ThrowsNotFoundException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BY_ID_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment.class), eq(1)))
+                .thenThrow(HttpClientErrorException.NotFound.class);
+
+        assertThatThrownBy(() -> environmentService.getEnvironmentById(1))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Environment not found with id: 1");
+    }
+
+    @Test
+    void testGetEnvironmentById_RestTemplateThrows_WrapsInServiceException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BY_ID_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment.class), eq(1)))
+                .thenThrow(new RestClientException("boom"));
+
+        assertThatThrownBy(() -> environmentService.getEnvironmentById(1))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Error getting environment by id: 1");
+    }
+
+    // getEnvironmentByName
+
+    @Test
+    void testGetEnvironmentByName_Success_ReturnsEnvironment() {
+        Environment environment = new Environment(1, "Env1", "2024-01-01");
+        Mockito.when(restTemplate.exchange(
+                        eq(BY_NAME_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment.class), eq("Env1")))
+                .thenReturn(ResponseEntity.ok(environment));
+
+        assertThat(environmentService.getEnvironmentByName("Env1")).isEqualTo(environment);
+    }
+
+    @Test
+    void testGetEnvironmentByName_NotFoundResponse_ThrowsNotFoundException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BY_NAME_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment.class), eq("Missing")))
+                .thenThrow(HttpClientErrorException.NotFound.class);
+
+        assertThatThrownBy(() -> environmentService.getEnvironmentByName("Missing"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Environment not found with name: Missing");
+    }
+
+    @Test
+    void testGetEnvironmentByName_RestTemplateThrows_WrapsInServiceException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BY_NAME_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment.class), eq("Env1")))
+                .thenThrow(new RestClientException("boom"));
+
+        assertThatThrownBy(() -> environmentService.getEnvironmentByName("Env1"))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Error getting environment by name: Env1");
+    }
+
+    // getEnvironmentOfEntity
+
+    @Test
+    void testGetEnvironmentOfEntity_Success_ReturnsEnvironment() {
+        Environment environment = new Environment(1, "Env1", "2024-01-01");
+        Mockito.when(restTemplate.exchange(
+                        eq(OF_ENTITY_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment.class), eq(7)))
+                .thenReturn(ResponseEntity.ok(environment));
+
+        assertThat(environmentService.getEnvironmentOfEntity(7)).isEqualTo(environment);
+    }
+
+    @Test
+    void testGetEnvironmentOfEntity_NotFoundResponse_ThrowsNotFoundException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(OF_ENTITY_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment.class), eq(7)))
+                .thenThrow(HttpClientErrorException.NotFound.class);
+
+        assertThatThrownBy(() -> environmentService.getEnvironmentOfEntity(7))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Environment not found for entity: 7");
+    }
+
+    @Test
+    void testGetEnvironmentOfEntity_RestTemplateThrows_WrapsInServiceException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(OF_ENTITY_URL), eq(HttpMethod.GET), nullRequestEntity(), eq(Environment.class), eq(7)))
+                .thenThrow(new RestClientException("boom"));
+
+        assertThatThrownBy(() -> environmentService.getEnvironmentOfEntity(7))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Error getting environment of entity: 7");
+    }
+
+    // createEnvironment - square-grid overload
+
+    @Test
+    void testCreateEnvironment_SquareOverload_SendsGridSizeOnly() {
+        Environment created = new Environment(1, "Env1", "2024-01-01");
+        Mockito.when(restTemplate.exchange(
+                        eq(BASE_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Environment.class)))
+                .thenReturn(ResponseEntity.ok(created));
+
+        Environment result = environmentService.createEnvironment("Env1", 2, 5);
+
+        assertThat(result).isEqualTo(created);
+        ArgumentCaptor<HttpEntity> captor = requestEntityCaptor();
+        Mockito.verify(restTemplate).exchange(
+                eq(BASE_URL), eq(HttpMethod.POST), captor.capture(), eq(Environment.class));
+        CreateEnvironmentRequest request = (CreateEnvironmentRequest) captor.getValue().getBody();
+        assertThat(request).isNotNull();
+        assertThat(request.getName()).isEqualTo("Env1");
+        assertThat(request.getNumGrids()).isEqualTo(2);
+        assertThat(request.getGridSize()).isEqualTo(5);
+        assertThat(request.getNumRows()).isNull();
+        assertThat(request.getNumColumns()).isNull();
+    }
+
+    // createEnvironment - rows/columns overload
+
+    @Test
+    void testCreateEnvironment_DimensionsOverload_SendsRowsAndColumnsWithoutGridSize() {
+        Environment created = new Environment(1, "Env1", "2024-01-01");
+        Mockito.when(restTemplate.exchange(
+                        eq(BASE_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Environment.class)))
+                .thenReturn(ResponseEntity.ok(created));
+
+        Environment result = environmentService.createEnvironment("Env1", 2, 3, 4);
+
+        assertThat(result).isEqualTo(created);
+        ArgumentCaptor<HttpEntity> captor = requestEntityCaptor();
+        Mockito.verify(restTemplate).exchange(
+                eq(BASE_URL), eq(HttpMethod.POST), captor.capture(), eq(Environment.class));
+        CreateEnvironmentRequest request = (CreateEnvironmentRequest) captor.getValue().getBody();
+        assertThat(request).isNotNull();
+        assertThat(request.getName()).isEqualTo("Env1");
+        assertThat(request.getNumGrids()).isEqualTo(2);
+        assertThat(request.getGridSize()).isNull();
+        assertThat(request.getNumRows()).isEqualTo(3);
+        assertThat(request.getNumColumns()).isEqualTo(4);
+    }
+
+    @Test
+    void testCreateEnvironment_NullBody_ThrowsServiceException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BASE_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Environment.class)))
+                .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
+
+        assertThatThrownBy(() -> environmentService.createEnvironment("Env1", 2, 5))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Error creating environment");
+    }
+
+    @Test
+    void testCreateEnvironment_NonSuccessStatus_ThrowsServiceException() {
+        Environment created = new Environment(1, "Env1", "2024-01-01");
+        Mockito.when(restTemplate.exchange(
+                        eq(BASE_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Environment.class)))
+                .thenReturn(new ResponseEntity<>(created, HttpStatus.BAD_REQUEST));
+
+        assertThatThrownBy(() -> environmentService.createEnvironment("Env1", 2, 5))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Error creating environment");
+    }
+
+    @Test
+    void testCreateEnvironment_RestTemplateThrows_WrapsInServiceException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BASE_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(Environment.class)))
+                .thenThrow(new RestClientException("boom"));
+
+        assertThatThrownBy(() -> environmentService.createEnvironment("Env1", 2, 5))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Error creating environment");
+    }
+
+    // deleteEnvironment
+
+    @Test
+    void testDeleteEnvironment_Success_ReturnsTrue() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BY_ID_URL), eq(HttpMethod.DELETE), nullRequestEntity(), eq(Void.class), eq(1)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        assertThat(environmentService.deleteEnvironment(1)).isTrue();
+    }
+
+    @Test
+    void testDeleteEnvironment_NotFoundStatus_ThrowsNotFoundException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BY_ID_URL), eq(HttpMethod.DELETE), nullRequestEntity(), eq(Void.class), eq(1)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+
+        assertThatThrownBy(() -> environmentService.deleteEnvironment(1))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Environment not found with id: 1");
+    }
+
+    @Test
+    void testDeleteEnvironment_NotFoundResponse_ThrowsNotFoundException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BY_ID_URL), eq(HttpMethod.DELETE), nullRequestEntity(), eq(Void.class), eq(1)))
+                .thenThrow(HttpClientErrorException.NotFound.class);
+
+        assertThatThrownBy(() -> environmentService.deleteEnvironment(1))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Environment not found with id: 1");
+    }
+
+    @Test
+    void testDeleteEnvironment_NonSuccessStatus_ThrowsServiceException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BY_ID_URL), eq(HttpMethod.DELETE), nullRequestEntity(), eq(Void.class), eq(1)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        assertThatThrownBy(() -> environmentService.deleteEnvironment(1))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Error deleting environment");
+    }
+
+    @Test
+    void testDeleteEnvironment_RestTemplateThrows_WrapsInServiceException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(BY_ID_URL), eq(HttpMethod.DELETE), nullRequestEntity(), eq(Void.class), eq(1)))
+                .thenThrow(new RestClientException("boom"));
+
+        assertThatThrownBy(() -> environmentService.deleteEnvironment(1))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Error deleting environment");
+    }
+
+    // updateEnvironmentName
+
+    @Test
+    void testUpdateEnvironmentName_Success_PatchesWithNameBody() {
+        Mockito.when(restTemplate.exchange(
+                        eq(NAME_URL), eq(HttpMethod.PATCH), any(HttpEntity.class), eq(Void.class), eq(1)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        assertThat(environmentService.updateEnvironmentName(1, "Renamed")).isTrue();
+
+        ArgumentCaptor<HttpEntity> captor = requestEntityCaptor();
+        Mockito.verify(restTemplate).exchange(
+                eq(NAME_URL), eq(HttpMethod.PATCH), captor.capture(), eq(Void.class), eq(1));
+        UpdateEnvironmentNameRequest request = (UpdateEnvironmentNameRequest) captor.getValue().getBody();
+        assertThat(request).isNotNull();
+        assertThat(request.getName()).isEqualTo("Renamed");
+    }
+
+    @Test
+    void testUpdateEnvironmentName_NotFoundStatus_ThrowsNotFoundException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(NAME_URL), eq(HttpMethod.PATCH), any(HttpEntity.class), eq(Void.class), eq(1)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+
+        assertThatThrownBy(() -> environmentService.updateEnvironmentName(1, "Renamed"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Environment not found with id: 1");
+    }
+
+    @Test
+    void testUpdateEnvironmentName_NotFoundResponse_ThrowsNotFoundException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(NAME_URL), eq(HttpMethod.PATCH), any(HttpEntity.class), eq(Void.class), eq(1)))
+                .thenThrow(HttpClientErrorException.NotFound.class);
+
+        assertThatThrownBy(() -> environmentService.updateEnvironmentName(1, "Renamed"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Environment not found with id: 1");
+    }
+
+    @Test
+    void testUpdateEnvironmentName_NonSuccessStatus_ThrowsServiceException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(NAME_URL), eq(HttpMethod.PATCH), any(HttpEntity.class), eq(Void.class), eq(1)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        assertThatThrownBy(() -> environmentService.updateEnvironmentName(1, "Renamed"))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Error updating environment name");
+    }
+
+    @Test
+    void testUpdateEnvironmentName_RestTemplateThrows_WrapsInServiceException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(NAME_URL), eq(HttpMethod.PATCH), any(HttpEntity.class), eq(Void.class), eq(1)))
+                .thenThrow(new RestClientException("boom"));
+
+        assertThatThrownBy(() -> environmentService.updateEnvironmentName(1, "Renamed"))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Error updating environment name");
+    }
+}


### PR DESCRIPTION
## Summary

- `EnvironmentServiceTest` is added, covering all eight public methods of `EnvironmentService` — the only client service in the repo that had no test class. Success paths, null-body and non-2xx branches, `NotFound` mapping, and generic `RestClientException` wrapping are all exercised, following the plain-JUnit + Mockito pattern established by `GridServiceTest` and `LocationServiceTest`.
- The request bodies of the two `createEnvironment` overloads are captured and asserted, so the `gridSize` shorthand and the `numRows`/`numColumns` form are pinned as genuinely different payloads; the `PATCH` rename payload is pinned the same way.
- `EnvironmentService`'s error handling is aligned with the try/catch-and-wrap style of its siblings. The previous `response.getStatusCode().isError()` checks were unreachable under `RestTemplate`'s default error handler, so a failed call propagated a raw `RestClientException` and was mapped by `GlobalExceptionHandler` to its generic "An unexpected error occurred" branch rather than the `ServiceException` branch.
- `HttpClientErrorException.NotFound` and 404 responses are now translated to `NotFoundException` for the by-id, by-name, of-entity, delete, and rename calls, so a missing environment surfaces as 404 instead of 500. A `catch (ServiceException e) { throw e; }` passthrough sits ahead of each generic catch, matching the fix made in #186 so domain exceptions are not rewrapped.
- A null or non-OK list response from `getAllEnvironments()` now yields an empty list instead of a `NullPointerException` out of `Arrays.asList(null)`.

No endpoint URL, request shape, or response shape was changed, so `docs/openapi/viron-api.json` and the Python SDK under `src/main/python` require no update.

## Test plan

- [ ] `./mvnw test -B` — not runnable in the sandbox this branch was authored in (no local JDK/Maven); the CI workflow's `./mvnw test -B` step on this branch is the authoritative signal and is checked before merge.
- [x] `pytest` — not applicable; no Python SDK file was touched.

Closes #185

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->