### PR TITLE
feat: add missing Java client service methods for three implemented endpoints

### DIFF
--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -32,7 +32,7 @@ Establish the core building blocks: project structure, models, DTOs, mapping, re
 Implement core service logic to support the REST API.
 
 11. **EnvironmentService** — Create, retrieve, update name, delete (cascade).  
-12. **GridService** — Lookups by ID, environment, or entity.  
+12. **GridService** — Lookups by ID, environment, or entity; update name.  
 13. **LocationService** — Manage locations, add/remove entities, lookups.  
 14. **EntityService** — Create, retrieve, delete entities and handle detach.
 

--- a/src/main/java/preponderous/viron/services/GridService.java
+++ b/src/main/java/preponderous/viron/services/GridService.java
@@ -3,13 +3,17 @@ package preponderous.viron.services;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import preponderous.viron.config.AuthTokenInterceptor;
 import preponderous.viron.config.ServiceConfig;
+import preponderous.viron.dto.UpdateGridNameRequest;
+import preponderous.viron.exceptions.NotFoundException;
 import preponderous.viron.exceptions.ServiceException;
 import preponderous.viron.models.Grid;
 
@@ -82,6 +86,33 @@ public class GridService {
         } catch (Exception e) {
             log.error("Error getting grid for entity {}: {}", entityId, e.getMessage());
             throw new ServiceException("Failed to fetch grid for entity: " + entityId, e);
+        }
+    }
+
+    public boolean updateGridName(int id, String name) {
+        try {
+            RestTemplate restTemplate = restTemplateBuilder.build();
+            ResponseEntity<Void> response = restTemplate.exchange(
+                    baseUrl + "/{id}/name",
+                    HttpMethod.PATCH,
+                    new HttpEntity<>(new UpdateGridNameRequest(name)),
+                    Void.class,
+                    id
+            );
+            if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
+                throw new NotFoundException("Grid not found with id: " + id);
+            }
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new ServiceException("Failed to update grid name");
+            }
+            return true;
+        } catch (HttpClientErrorException.NotFound e) {
+            throw new NotFoundException("Grid not found with id: " + id);
+        } catch (ServiceException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Error updating name for grid {}: {}", id, e.getMessage());
+            throw new ServiceException("Failed to update grid name", e);
         }
     }
 }

--- a/src/main/java/preponderous/viron/services/LocationService.java
+++ b/src/main/java/preponderous/viron/services/LocationService.java
@@ -93,6 +93,22 @@ public class LocationService {
         }
     }
 
+    public List<Location> getUnoccupiedLocationsInGrid(int gridId) {
+        try {
+            ResponseEntity<Location[]> response = restTemplate.getForEntity(
+                    baseUrl + "/grid/{gridId}/unoccupied",
+                    Location[].class,
+                    gridId
+            );
+            return response.getStatusCode() == HttpStatus.OK && response.getBody() != null
+                    ? Arrays.asList(response.getBody())
+                    : Collections.emptyList();
+        } catch (Exception e) {
+            log.error("Error getting unoccupied locations in grid {}: {}", gridId, e.getMessage());
+            throw new ServiceException("Error getting unoccupied locations in grid: " + gridId, e);
+        }
+    }
+
     public Location getLocationOfEntity(int entityId) {
         try {
             ResponseEntity<Location> response = restTemplate.getForEntity(
@@ -227,6 +243,24 @@ public class LocationService {
         } catch (Exception e) {
             log.error("Error checking occupancy for location {}: {}", locationId, e.getMessage());
             throw new ServiceException("Error checking occupancy for location: " + locationId, e);
+        }
+    }
+
+    public List<Location> getNeighbors(int locationId) {
+        try {
+            ResponseEntity<Location[]> response = restTemplate.getForEntity(
+                    baseUrl + "/{locationId}/neighbors",
+                    Location[].class,
+                    locationId
+            );
+            return response.getStatusCode() == HttpStatus.OK && response.getBody() != null
+                    ? Arrays.asList(response.getBody())
+                    : Collections.emptyList();
+        } catch (HttpClientErrorException.NotFound e) {
+            throw new NotFoundException("Location not found with id: " + locationId);
+        } catch (Exception e) {
+            log.error("Error getting neighbors of location {}: {}", locationId, e.getMessage());
+            throw new ServiceException("Error getting neighbors of location: " + locationId, e);
         }
     }
 

--- a/src/test/java/preponderous/viron/services/GridServiceTest.java
+++ b/src/test/java/preponderous/viron/services/GridServiceTest.java
@@ -2,14 +2,20 @@ package preponderous.viron.services;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import preponderous.viron.config.ServiceConfig;
+import preponderous.viron.dto.UpdateGridNameRequest;
+import preponderous.viron.exceptions.NotFoundException;
 import preponderous.viron.exceptions.ServiceException;
 import preponderous.viron.models.Grid;
 
@@ -24,6 +30,7 @@ import static org.mockito.ArgumentMatchers.eq;
 public class GridServiceTest {
 
     private static final String BASE_URL = "http://localhost:8080/api/v1/grids";
+    private static final String NAME_URL = BASE_URL + "/{id}/name";
 
     private RestTemplate restTemplate;
     private GridService gridService;
@@ -41,6 +48,10 @@ public class GridServiceTest {
         serviceConfig.setVironPort(8080);
 
         gridService = new GridService(restTemplateBuilder, serviceConfig);
+    }
+
+    private static ArgumentCaptor<HttpEntity> requestEntityCaptor() {
+        return ArgumentCaptor.forClass(HttpEntity.class);
     }
 
     @Test
@@ -146,5 +157,65 @@ public class GridServiceTest {
         assertThatThrownBy(() -> gridService.getGridOfEntity(9))
                 .isInstanceOf(ServiceException.class)
                 .hasMessageContaining("Failed to fetch grid for entity: 9");
+    }
+
+    @Test
+    void testUpdateGridName_Success_PatchesWithNameBody() {
+        Mockito.when(restTemplate.exchange(
+                        eq(NAME_URL), eq(HttpMethod.PATCH), any(HttpEntity.class), eq(Void.class), eq(1)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        assertThat(gridService.updateGridName(1, "Renamed")).isTrue();
+
+        ArgumentCaptor<HttpEntity> captor = requestEntityCaptor();
+        Mockito.verify(restTemplate).exchange(
+                eq(NAME_URL), eq(HttpMethod.PATCH), captor.capture(), eq(Void.class), eq(1));
+        UpdateGridNameRequest request = (UpdateGridNameRequest) captor.getValue().getBody();
+        assertThat(request).isNotNull();
+        assertThat(request.getName()).isEqualTo("Renamed");
+    }
+
+    @Test
+    void testUpdateGridName_NotFoundStatus_ThrowsNotFoundException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(NAME_URL), eq(HttpMethod.PATCH), any(HttpEntity.class), eq(Void.class), eq(1)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+
+        assertThatThrownBy(() -> gridService.updateGridName(1, "Renamed"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Grid not found with id: 1");
+    }
+
+    @Test
+    void testUpdateGridName_NotFoundResponse_ThrowsNotFoundException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(NAME_URL), eq(HttpMethod.PATCH), any(HttpEntity.class), eq(Void.class), eq(1)))
+                .thenThrow(HttpClientErrorException.NotFound.class);
+
+        assertThatThrownBy(() -> gridService.updateGridName(1, "Renamed"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Grid not found with id: 1");
+    }
+
+    @Test
+    void testUpdateGridName_NonSuccessStatus_ThrowsServiceException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(NAME_URL), eq(HttpMethod.PATCH), any(HttpEntity.class), eq(Void.class), eq(1)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        assertThatThrownBy(() -> gridService.updateGridName(1, "Renamed"))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Failed to update grid name");
+    }
+
+    @Test
+    void testUpdateGridName_RestTemplateThrows_WrapsInServiceException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(NAME_URL), eq(HttpMethod.PATCH), any(HttpEntity.class), eq(Void.class), eq(1)))
+                .thenThrow(new RestClientException("boom"));
+
+        assertThatThrownBy(() -> gridService.updateGridName(1, "Renamed"))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Failed to update grid name");
     }
 }

--- a/src/test/java/preponderous/viron/services/LocationServiceTest.java
+++ b/src/test/java/preponderous/viron/services/LocationServiceTest.java
@@ -188,6 +188,35 @@ public class LocationServiceTest {
                 .hasMessage("Error getting locations in grid: 7");
     }
 
+    // getUnoccupiedLocationsInGrid
+
+    @Test
+    void testGetUnoccupiedLocationsInGrid_Success_ReturnsLocations() {
+        Location[] locations = {new Location(1, 0, 0), new Location(2, 0, 1)};
+        Mockito.when(restTemplate.getForEntity(eq(BASE_URL + "/grid/{gridId}/unoccupied"), eq(Location[].class), eq(7)))
+                .thenReturn(ResponseEntity.ok(locations));
+
+        assertThat(locationService.getUnoccupiedLocationsInGrid(7)).hasSize(2);
+    }
+
+    @Test
+    void testGetUnoccupiedLocationsInGrid_NullBody_ReturnsEmptyList() {
+        Mockito.when(restTemplate.getForEntity(eq(BASE_URL + "/grid/{gridId}/unoccupied"), eq(Location[].class), eq(7)))
+                .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
+
+        assertThat(locationService.getUnoccupiedLocationsInGrid(7)).isEmpty();
+    }
+
+    @Test
+    void testGetUnoccupiedLocationsInGrid_RestTemplateThrows_WrapsInServiceException() {
+        Mockito.when(restTemplate.getForEntity(eq(BASE_URL + "/grid/{gridId}/unoccupied"), eq(Location[].class), eq(7)))
+                .thenThrow(new RestClientException("boom"));
+
+        assertThatThrownBy(() -> locationService.getUnoccupiedLocationsInGrid(7))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Error getting unoccupied locations in grid: 7");
+    }
+
     // getLocationOfEntity
 
     @Test
@@ -486,6 +515,45 @@ public class LocationServiceTest {
         assertThatThrownBy(() -> locationService.isLocationOccupied(5))
                 .isExactlyInstanceOf(ServiceException.class)
                 .hasMessage("Error checking occupancy for location: 5");
+    }
+
+    // getNeighbors
+
+    @Test
+    void testGetNeighbors_Success_ReturnsLocations() {
+        Location[] neighbors = {new Location(4, 0, 1), new Location(6, 1, 0)};
+        Mockito.when(restTemplate.getForEntity(eq(BASE_URL + "/{locationId}/neighbors"), eq(Location[].class), eq(5)))
+                .thenReturn(ResponseEntity.ok(neighbors));
+
+        assertThat(locationService.getNeighbors(5)).hasSize(2);
+    }
+
+    @Test
+    void testGetNeighbors_NullBody_ReturnsEmptyList() {
+        Mockito.when(restTemplate.getForEntity(eq(BASE_URL + "/{locationId}/neighbors"), eq(Location[].class), eq(5)))
+                .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
+
+        assertThat(locationService.getNeighbors(5)).isEmpty();
+    }
+
+    @Test
+    void testGetNeighbors_HttpNotFound_ThrowsNotFoundException() {
+        Mockito.when(restTemplate.getForEntity(eq(BASE_URL + "/{locationId}/neighbors"), eq(Location[].class), eq(5)))
+                .thenThrow(HttpClientErrorException.NotFound.class);
+
+        assertThatThrownBy(() -> locationService.getNeighbors(5))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Location not found with id: 5");
+    }
+
+    @Test
+    void testGetNeighbors_RestTemplateThrows_WrapsInServiceException() {
+        Mockito.when(restTemplate.getForEntity(eq(BASE_URL + "/{locationId}/neighbors"), eq(Location[].class), eq(5)))
+                .thenThrow(new RestClientException("boom"));
+
+        assertThatThrownBy(() -> locationService.getNeighbors(5))
+                .isExactlyInstanceOf(ServiceException.class)
+                .hasMessage("Error getting neighbors of location: 5");
     }
 
     // moveEntityToLocation


### PR DESCRIPTION
## Summary

- `GridService.updateGridName(int id, String name)` was added, issuing `PATCH /api/v1/grids/{id}/name` with an `UpdateGridNameRequest` body and mirroring the shape and error handling of `EnvironmentService.updateEnvironmentName` (404 mapped to `NotFoundException`, non-2xx and transport errors wrapped in `ServiceException`).
- `LocationService.getUnoccupiedLocationsInGrid(int gridId)` was added, issuing `GET /api/v1/locations/grid/{gridId}/unoccupied` and following the existing `getLocationsInGrid` pattern (empty list on non-OK or null body, `ServiceException` wrapping).
- `LocationService.getNeighbors(int locationId)` was added, issuing `GET /api/v1/locations/{locationId}/neighbors` and following the existing `getEntityIdsAtLocation` pattern, since that endpoint can answer 404.
- Tests were added to `GridServiceTest` and `LocationServiceTest` covering, for each new method, the success path, the null-body path, the 404 translation where applicable, and the generic `RestClientException` wrapping.

No controller, DTO, OpenAPI spec, or Python SDK change was required — the three endpoints are already implemented by the controllers, already present in `docs/openapi/viron-api.json`, and already exposed by the Python SDK. This change closes the Java-side gap only.

## Test plan

- [x] `mvn -B test` — BUILD SUCCESS, 393 tests run, 0 failures, 0 errors (`GridServiceTest` 15, `LocationServiceTest` 54). Note that `./mvnw` was unavailable to this session's tooling, so the system `mvn` was used locally; the CI check on this PR head remains the authoritative anchor and invokes `./mvnw`.
- [x] The Python client was not modified, so `pytest` coverage is unaffected.
- [x] Each new method's URL template and verb were checked against `GridController` / `LocationController` and against `docs/openapi/viron-api.json`.

## Deferred work

Issue #130 (OpenAPI-first codegen / spec-drift guard) was not picked up this cycle: it calls for a build-tooling evaluation that changes `pom.xml` and the CI workflow, which is outside the scope of a polish-sized PR and warrants a human decision on the approach.

Closes #188

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->