### PR TITLE
fix: enforce the single-placement invariant and unblock deleting a placed entity

### DIFF
--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -50,7 +50,7 @@ Deliver a working, tested API that supports:
 - [x] `GET /api/v1/locations/{locationId}/entities` – Retrieve the IDs of the entities at a location.
 - [x] `GET /api/v1/locations/{locationId}/occupied` – Report whether a location holds any entities.
 - [x] `GET /api/v1/locations/{locationId}/neighbors` – Retrieve the locations adjacent to a location within its grid.
-- [x] `PUT /api/v1/locations/{locationId}/entity/{entityId}` – Add an entity to a location.
+- [x] `PUT /api/v1/locations/{locationId}/entity/{entityId}` – Place an unplaced entity at a location (no-op when the entity is already there, conflict when it is placed elsewhere).
 - [x] `PUT /api/v1/locations/{locationId}/entity/{entityId}/move` – Move a placed entity to an adjacent, unoccupied location in the same grid.
 - [x] `DELETE /api/v1/locations/{locationId}/entity/{entityId}` – Remove an entity from a specific location.
 - [x] `DELETE /api/v1/locations/entity/{entityId}` – Remove an entity from its current location.

--- a/docs/openapi/viron-api.json
+++ b/docs/openapi/viron-api.json
@@ -370,14 +370,21 @@
     "/api/v1/locations/{locationId}/entity/{entityId}": {
       "put": {
         "summary": "Add entity to location",
+        "description": "Places an unplaced entity at the location. An entity occupies at most one location, so the request is a no-op when the entity is already at that location and a conflict when it is placed elsewhere.",
         "parameters": [
           { "$ref": "#/components/parameters/LocationIdParam" },
           { "$ref": "#/components/parameters/EntityIdParam" }
         ],
         "responses": {
-          "200": { "description": "Entity added" },
+          "200": { "description": "Entity added, or already present at that location" },
           "404": {
-            "description": "Location not found with that id",
+            "description": "Location or entity not found with that id",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+            }
+          },
+          "409": {
+            "description": "Entity is already placed at a different location",
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
             }

--- a/src/main/java/preponderous/viron/controllers/LocationController.java
+++ b/src/main/java/preponderous/viron/controllers/LocationController.java
@@ -12,6 +12,7 @@ import preponderous.viron.exceptions.NotFoundException;
 import preponderous.viron.exceptions.ServiceException;
 import preponderous.viron.mappers.LocationMapper;
 import preponderous.viron.models.Location;
+import preponderous.viron.repositories.EntityRepository;
 import preponderous.viron.repositories.LocationRepository;
 
 import jakarta.validation.constraints.Min;
@@ -26,6 +27,7 @@ import java.util.stream.Collectors;
 @Validated
 public class LocationController {
     private final LocationRepository locationRepository;
+    private final EntityRepository entityRepository;
     private final LocationMapper locationMapper;
 
     @GetMapping
@@ -66,10 +68,26 @@ public class LocationController {
         return locationMapper.toDto(location);
     }
 
+    /**
+     * Places an unplaced entity at {@code locationId}. An entity occupies at most one location,
+     * so a request for an entity that is already placed elsewhere is a conflict; a request for an
+     * entity already at the target is a no-op, keeping the {@code PUT} idempotent.
+     */
     @PutMapping("/{locationId}/entity/{entityId}")
     public void addEntityToLocation(@PathVariable("entityId") @Min(1) int entityId, @PathVariable("locationId") @Min(1) int locationId) {
         if (locationRepository.findById(locationId).isEmpty()) {
             throw new NotFoundException("Location not found with id: " + locationId);
+        }
+        if (entityRepository.findById(entityId).isEmpty()) {
+            throw new NotFoundException("Entity not found with id: " + entityId);
+        }
+        Optional<Location> currentLocation = locationRepository.findByEntityId(entityId);
+        if (currentLocation.isPresent()) {
+            if (currentLocation.get().getLocationId() == locationId) {
+                return;
+            }
+            throw new ConflictException("Entity " + entityId + " is already placed at location "
+                    + currentLocation.get().getLocationId());
         }
         if (!locationRepository.addEntityToLocation(entityId, locationId)) {
             throw new ServiceException("Failed to add entity " + entityId + " to location " + locationId);

--- a/src/main/java/preponderous/viron/repositories/EntityRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/EntityRepositoryImpl.java
@@ -84,10 +84,18 @@ public class EntityRepositoryImpl implements EntityRepository {
         return null;
     }
 
+    /**
+     * Deletes the entity and its placement, if any.
+     *
+     * <p>{@code viron.entity_location} carries a foreign key onto {@code viron.entity}, so the
+     * placement row has to be cleared first or the entity delete is rejected by the constraint.
+     * An entity that is not placed has no row to clear, which is why the first statement's result
+     * is not part of the outcome — only the entity delete itself is reported.
+     */
     @Override
     public boolean deleteById(int id) {
-        String query = "DELETE FROM viron.entity WHERE entity_id = ?";
-        return dbInteractions.update(query, id);
+        dbInteractions.update("DELETE FROM viron.entity_location WHERE entity_id = ?", id);
+        return dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = ?", id);
     }
 
     @Override

--- a/src/main/java/preponderous/viron/services/LocationService.java
+++ b/src/main/java/preponderous/viron/services/LocationService.java
@@ -143,11 +143,16 @@ public class LocationService {
             if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
                 throw new NotFoundException("Location or entity not found");
             }
+            if (response.getStatusCode() == HttpStatus.CONFLICT) {
+                throw new ConflictException("Entity " + entityId + " is already placed at another location");
+            }
             if (!response.getStatusCode().is2xxSuccessful()) {
                 throw new ServiceException("Failed to add entity to location");
             }
         } catch (HttpClientErrorException.NotFound e) {
             throw new NotFoundException("Location or entity not found");
+        } catch (HttpClientErrorException.Conflict e) {
+            throw new ConflictException("Entity " + entityId + " is already placed at another location");
         } catch (ServiceException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/python/preponderous/viron/services/locationService.py
+++ b/src/main/python/preponderous/viron/services/locationService.py
@@ -61,6 +61,8 @@ class LocationService:
         response = requests.put(f"{self.get_base_url()}/{location_id}/entity/{entity_id}", headers=self.get_auth_headers())
         if response.status_code == 404:
             raise Exception("Location or entity not found")
+        if response.status_code == 409:
+            raise Exception(f"Entity {entity_id} is already placed at another location")
         response.raise_for_status()
 
     def remove_entity_from_location(self, entity_id: int, location_id: int) -> None:

--- a/src/test/java/preponderous/viron/controllers/LocationControllerTest.java
+++ b/src/test/java/preponderous/viron/controllers/LocationControllerTest.java
@@ -12,7 +12,9 @@ import preponderous.viron.config.DbConfig;
 import preponderous.viron.database.DbInteractions;
 import preponderous.viron.dto.LocationDto;
 import preponderous.viron.mappers.LocationMapper;
+import preponderous.viron.models.Entity;
 import preponderous.viron.models.Location;
+import preponderous.viron.repositories.EntityRepository;
 import preponderous.viron.repositories.LocationRepository;
 
 import java.util.Collections;
@@ -34,6 +36,9 @@ class LocationControllerTest {
 
     @MockBean
     private LocationRepository locationRepository;
+
+    @MockBean
+    private EntityRepository entityRepository;
 
     @MockBean
     private LocationMapper locationMapper;
@@ -332,6 +337,8 @@ class LocationControllerTest {
     @Test
     void addEntityToLocation_Success() throws Exception {
         when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(entityRepository.findById(1)).thenReturn(Optional.of(new Entity(1, "Entity1", "2024-01-01")));
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.empty());
         when(locationRepository.addEntityToLocation(1, 2)).thenReturn(true);
 
         mockMvc.perform(put("/api/v1/locations/2/entity/1"))
@@ -348,11 +355,67 @@ class LocationControllerTest {
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.message").value("Location not found with id: 2"));
+
+        verify(locationRepository, never()).addEntityToLocation(anyInt(), anyInt());
+    }
+
+    @Test
+    void addEntityToLocation_EntityNotFound() throws Exception {
+        when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(entityRepository.findById(1)).thenReturn(Optional.empty());
+
+        mockMvc.perform(put("/api/v1/locations/2/entity/1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("Entity not found with id: 1"));
+
+        verify(locationRepository, never()).addEntityToLocation(anyInt(), anyInt());
+    }
+
+    @Test
+    void addEntityToLocation_AlreadyAtTargetLocation_IsNoOp() throws Exception {
+        when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(entityRepository.findById(1)).thenReturn(Optional.of(new Entity(1, "Entity1", "2024-01-01")));
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(2, 10, 20)));
+
+        mockMvc.perform(put("/api/v1/locations/2/entity/1"))
+                .andExpect(status().isOk());
+
+        verify(locationRepository, never()).addEntityToLocation(anyInt(), anyInt());
+    }
+
+    @Test
+    void addEntityToLocation_AlreadyAtAnotherLocation_Conflict() throws Exception {
+        when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(entityRepository.findById(1)).thenReturn(Optional.of(new Entity(1, "Entity1", "2024-01-01")));
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(7, 30, 40)));
+
+        mockMvc.perform(put("/api/v1/locations/2/entity/1"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.message").value("Entity 1 is already placed at location 7"));
+
+        verify(locationRepository, never()).addEntityToLocation(anyInt(), anyInt());
+    }
+
+    @Test
+    void addEntityToLocation_UpdateFails() throws Exception {
+        when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(entityRepository.findById(1)).thenReturn(Optional.of(new Entity(1, "Entity1", "2024-01-01")));
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.empty());
+        when(locationRepository.addEntityToLocation(1, 2)).thenReturn(false);
+
+        mockMvc.perform(put("/api/v1/locations/2/entity/1"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.message").value("Failed to add entity 1 to location 2"));
     }
 
     @Test
     void addEntityToLocation_RepositoryThrowsException() throws Exception {
         when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(entityRepository.findById(1)).thenReturn(Optional.of(new Entity(1, "Entity1", "2024-01-01")));
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.empty());
         when(locationRepository.addEntityToLocation(1, 2)).thenThrow(new RuntimeException("Database error"));
 
         mockMvc.perform(put("/api/v1/locations/2/entity/1"))

--- a/src/test/java/preponderous/viron/repositories/EntityRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/EntityRepositoryImplTest.java
@@ -1,6 +1,7 @@
 package preponderous.viron.repositories;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -517,6 +518,45 @@ public class EntityRepositoryImplTest {
 
         // Assert
         assertThat(result).isFalse();
+    }
+
+    @Test
+    public void testDeleteById_ClearsPlacementBeforeDeletingEntity() {
+        // Arrange
+        int entityId = 1;
+        Mockito.when(dbInteractions.update("DELETE FROM viron.entity_location WHERE entity_id = ?", entityId))
+                .thenReturn(true);
+        Mockito.when(dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = ?", entityId))
+                .thenReturn(true);
+
+        EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
+
+        // Act
+        boolean result = repository.deleteById(entityId);
+
+        // Assert
+        assertThat(result).isTrue();
+        InOrder inOrder = Mockito.inOrder(dbInteractions);
+        inOrder.verify(dbInteractions).update("DELETE FROM viron.entity_location WHERE entity_id = ?", entityId);
+        inOrder.verify(dbInteractions).update("DELETE FROM viron.entity WHERE entity_id = ?", entityId);
+    }
+
+    @Test
+    public void testDeleteById_UnplacedEntity_ReturnsTrueEvenThoughNoPlacementWasCleared() {
+        // Arrange
+        int entityId = 1;
+        Mockito.when(dbInteractions.update("DELETE FROM viron.entity_location WHERE entity_id = ?", entityId))
+                .thenReturn(false); // no placement row existed
+        Mockito.when(dbInteractions.update("DELETE FROM viron.entity WHERE entity_id = ?", entityId))
+                .thenReturn(true);
+
+        EntityRepositoryImpl repository = new EntityRepositoryImpl(dbInteractions);
+
+        // Act
+        boolean result = repository.deleteById(entityId);
+
+        // Assert
+        assertThat(result).isTrue();
     }
 
     @Test

--- a/src/test/java/preponderous/viron/services/LocationServiceTest.java
+++ b/src/test/java/preponderous/viron/services/LocationServiceTest.java
@@ -307,6 +307,30 @@ public class LocationServiceTest {
     }
 
     @Test
+    void testAddEntityToLocation_ConflictStatus_ThrowsConflictException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(ENTITY_AT_LOCATION_URL), eq(HttpMethod.PUT), nullRequestEntity(),
+                        eq(Void.class), eq(5), eq(2)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.CONFLICT));
+
+        assertThatThrownBy(() -> locationService.addEntityToLocation(2, 5))
+                .isInstanceOf(ConflictException.class)
+                .hasMessage("Entity 2 is already placed at another location");
+    }
+
+    @Test
+    void testAddEntityToLocation_HttpConflict_ThrowsConflictException() {
+        Mockito.when(restTemplate.exchange(
+                        eq(ENTITY_AT_LOCATION_URL), eq(HttpMethod.PUT), nullRequestEntity(),
+                        eq(Void.class), eq(5), eq(2)))
+                .thenThrow(HttpClientErrorException.Conflict.class);
+
+        assertThatThrownBy(() -> locationService.addEntityToLocation(2, 5))
+                .isInstanceOf(ConflictException.class)
+                .hasMessage("Entity 2 is already placed at another location");
+    }
+
+    @Test
     void testAddEntityToLocation_RestTemplateThrows_WrapsInServiceException() {
         Mockito.when(restTemplate.exchange(
                         eq(ENTITY_AT_LOCATION_URL), eq(HttpMethod.PUT), nullRequestEntity(),

--- a/src/test/python/preponderous/viron/services/test_locationService.py
+++ b/src/test/python/preponderous/viron/services/test_locationService.py
@@ -140,6 +140,24 @@ def test_add_entity_to_location(mock_put):
 
     mock_put.assert_called_with("http://localhost:9999/api/v1/locations/1/entity/1", headers={})
 
+@patch('requests.put')
+def test_add_entity_to_location_not_found(mock_put):
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_put.return_value = mock_response
+
+    with pytest.raises(Exception):
+        service.add_entity_to_location(1, 1)
+
+@patch('requests.put')
+def test_add_entity_to_location_conflict(mock_put):
+    mock_response = Mock()
+    mock_response.status_code = 409
+    mock_put.return_value = mock_response
+
+    with pytest.raises(Exception):
+        service.add_entity_to_location(1, 1)
+
 @patch('requests.delete')
 def test_remove_entity_from_location(mock_delete):
     mock_response = Mock()


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

Three defects around entity placement are fixed, all rooted in the same missing guards
between `viron.entity` and the `viron.entity_location` join table.

- **`PUT /api/v1/locations/{locationId}/entity/{entityId}` — entity existence (#190).**
  Only the location was validated before the insert, so an unknown entity id violated
  the `entity_location` foreign key, was swallowed by `DbInteractions.update`, and
  surfaced as a 500. An entity-existence guard is added, so an unknown entity id is now
  reported as **404**, matching how every other resource in this repo reports a missing id.

- **`PUT /api/v1/locations/{locationId}/entity/{entityId}` — single-placement invariant (#191).**
  The placement row was inserted unconditionally, so an entity could hold rows for two
  locations at once — a state that `findByEntityId`, `moveEntityToLocation` and
  `removeEntityFromCurrentLocation` all silently mishandle. A placement guard is added:
  an entity already at the requested location makes the request a **no-op success**
  (keeping `PUT` idempotent, where a repeat previously violated the composite primary key
  and became a 500), and an entity placed at a *different* location is rejected with
  **409**, the status this repo already uses for a placement conflict on the move endpoint.

- **`DELETE /api/v1/entities/{id}` — deleting a placed entity (#192).**
  `EntityRepositoryImpl.deleteById` issued only the entity delete, which any surviving
  placement row blocked via the foreign key, making a placed entity undeletable through
  the API. The entity's `entity_location` rows are now cleared first, mirroring the
  ordering `EnvironmentController.deleteEnvironment` already performs for the cascade it
  owns. The result of the entity delete alone is returned, since an unplaced entity has
  no placement row to clear.

Contract documentation and both client SDKs are updated in the same change, per this
repo's convention of keeping the spec in sync with the code:

- `docs/openapi/viron-api.json` — the 404 description is widened to cover a missing
  entity, a 409 response is documented, and the 200 description notes the no-op case.
  (No 500 was documented for `DELETE /api/v1/entities/{id}`, so nothing needed to be
  removed there.)
- `docs/MVP.md` — the endpoint line now describes the actual placement semantics.
- `services/LocationService.java` (Java client) and `services/locationService.py`
  (Python client) — both now translate a 409 rather than falling through to a generic
  failure.

## Test plan

- [x] `python3 -m pytest` — **107 passed**, covering the two new Python client cases.
- [ ] `./mvnw test -B` — **not runnable in this environment**: `java`, `mvn` and `./mvnw`
      are permission-denied by the sandbox this session runs in. The GitHub Actions
      `build` job on this branch is therefore the authoritative Java signal and is being
      relied upon in its place; merging is gated on it passing.
- New Java coverage added in this change:
  - `LocationControllerTest` — entity-not-found (404), already-at-target (no-op 200),
    already-elsewhere (409), unplaced-success, update-fails (500), and a
    `never()` assertion that the repository write is skipped on each rejected path.
  - `LocationServiceTest` — 409 status and `HttpClientErrorException.Conflict` both
    mapped to `ConflictException`.
  - `EntityRepositoryImplTest` — `InOrder` assertion that the placement delete precedes
    the entity delete, plus the unplaced-entity case confirming the outcome is taken from
    the entity delete alone.

A controller-level "204 for a placed entity" test was considered per #192 and deliberately
not added: `EntityController` reaches the database only through a mocked
`EntityRepository` in that test class, so such a test would be indistinguishable from the
existing `deleteEntity_ReturnsNoContent` case. The ordering fix is asserted at the
repository layer instead, which is where it lives.

## Known limitation

No transaction wraps the two statements in `deleteById`, as called out in #192 — this
repo uses raw JDBC through `DbInteractions` with no `@Transactional` usage anywhere. The
failure window is narrow and strictly better than the current guaranteed failure.

Closes #190
Closes #191
Closes #192

---

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).
