### PR TITLE
chore: release version 0.7.0-SNAPSHOT-8-8-2026

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get install -y openjdk-21-jre
 WORKDIR /app
 
 # Copy the jar file from the build stage
-COPY --from=build /app/target/viron-0.6.0-SNAPSHOT.jar /app/viron-0.6.0-SNAPSHOT.jar
+COPY --from=build /app/target/viron-0.7.0-SNAPSHOT-8-8-2026.jar /app/viron-0.7.0-SNAPSHOT-8-8-2026.jar
 
 # Run the jar file
-CMD ["java", "-jar", "viron-0.6.0-SNAPSHOT.jar"]
+CMD ["java", "-jar", "viron-0.7.0-SNAPSHOT-8-8-2026.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>preponderous</groupId>
     <artifactId>viron</artifactId>
-    <version>0.6.0-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT-8-8-2026</version>
     <name>viron</name>
     <description>Environment manager</description>
     <properties>


### PR DESCRIPTION
## Summary

The version has been bumped from `0.6.0-SNAPSHOT` to `0.7.0-SNAPSHOT-8-8-2026` in `pom.xml`.

The bump marks viron moving to an AI-first development approach: day-to-day feature work,
grooming, review and maintenance now run through AI agents working directly against this
repository, with the maintainers setting direction and approving what lands.

It is not a compatibility break. Behaviour, configuration and stored data are unchanged, and
existing installations can upgrade in place — the version marks a change in how the project is
built, not in what it does.

## Snapshot designation

The dated snapshot designation follows the precedent set by Medieval Factions'
`6.0.0-SNAPSHOT-7-25-2026`: the AI-first line has not yet been verified in live operation, and
the designation stays until it has.

## Notes

This is part of a garden-wide pass applying the same bump across every project tended by
Gardener. Only version metadata and the documentation that cites it has been changed; no functional code was touched.

---
*Drafted by Claude on behalf of Daniel Stephenson.*
