### PR TITLE
refactor: pool database connections, and fix the blocked local-run configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The MVP implements the endpoints defined in `docs/openapi/viron-api.json` and do
 - Lombok
 - MapStruct (model ↔ DTO mapping)
 - Spring Security (OAuth2 resource server / JWT)
-- PostgreSQL (persistence layer)
+- PostgreSQL (persistence layer), pooled with HikariCP
 - Maven (build tool)
 - Docker + Docker Compose (deployment)
 - Swagger/OpenAPI (API documentation)
@@ -129,16 +129,22 @@ viron/
 ### Installation
 mvn clean install
 
+### Configuration
+Copy `sample.env` to `.env` and review the values before starting anything.  
+`JWT_SECRET` is required — it has no default, so the service will not start until it is set.  
+It must match the secret used by the UserAuth service that issues the tokens, and for `HS256`
+it must be at least 32 bytes.
+
 ### Running Locally
 docker-compose up --build  
-API will be available at: http://localhost:8080
+API will be available at: http://localhost:9999
 
 ---
 
 ## 📜 API Documentation
 
 Once running, you can view the interactive API docs:  
-http://localhost:8080/swagger-ui.html  
+http://localhost:9999/swagger-ui.html  
 or refer to the `docs/openapi/viron-api.json` file.
 
 ---

--- a/compose.yml
+++ b/compose.yml
@@ -27,6 +27,10 @@ services:
       SERVICE_VIRON_HOST: ${SERVICE_VIRON_HOST}
       SERVICE_VIRON_PORT: ${SERVICE_VIRON_PORT}
       VIRON_DEBUG_ENABLED: ${VIRON_DEBUG_ENABLED:-false}
+      # Required — the service does not start without it. Must match UserAuth's secret.
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_ISSUER: ${JWT_ISSUER:-userauth}
+      JWT_ALGORITHM: ${JWT_ALGORITHM:-HS256}
     depends_on:
       - postgres
 

--- a/compose.yml
+++ b/compose.yml
@@ -28,7 +28,8 @@ services:
       SERVICE_VIRON_PORT: ${SERVICE_VIRON_PORT}
       VIRON_DEBUG_ENABLED: ${VIRON_DEBUG_ENABLED:-false}
       # Required — the service does not start without it. Must match UserAuth's secret.
-      JWT_SECRET: ${JWT_SECRET}
+      # The :? form makes compose refuse to start rather than pass an empty secret through.
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET must be set; see sample.env}
       JWT_ISSUER: ${JWT_ISSUER:-userauth}
       JWT_ALGORITHM: ${JWT_ALGORITHM:-HS256}
     depends_on:

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,13 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
+        <!-- Supplies HikariCP (the connection pool behind DbInteractions) and spring-jdbc's
+             DataSourceUtils, which makes connection acquisition transaction-aware. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/sample.env
+++ b/sample.env
@@ -19,3 +19,10 @@ SERVICE_VIRON_PORT=9999
 # debug
 # Registers the /api/v1/debug data-seeding endpoints. Leave false outside local/dev.
 VIRON_DEBUG_ENABLED=false
+
+# jwt
+# Required: the service refuses to start without it. Must match the UserAuth service's
+# JWT_SECRET, and for HS256 must be at least 32 bytes. Replace the sample value below.
+JWT_SECRET=replace-me-with-the-userauth-secret-at-least-32-bytes
+JWT_ISSUER=userauth
+JWT_ALGORITHM=HS256

--- a/src/main/java/preponderous/viron/config/DataSourceConfig.java
+++ b/src/main/java/preponderous/viron/config/DataSourceConfig.java
@@ -1,0 +1,42 @@
+// Copyright (c) 2024 Preponderous Software
+// MIT License
+
+package preponderous.viron.config;
+
+import javax.sql.DataSource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Supplies the pooled {@link DataSource} that
+ * {@link preponderous.viron.database.DbInteractions} draws connections from.
+ *
+ * <p>The pool is built from {@link DbConfig} rather than Spring Boot's
+ * {@code spring.datasource.*} properties, so the existing {@code database.*} property
+ * names keep working. Declaring the bean here also makes Spring Boot's
+ * {@code DataSourceAutoConfiguration} back off, so exactly one pool exists.
+ *
+ * <p>The pool is deliberately constructed with setters rather than
+ * {@code new HikariDataSource(HikariConfig)}: the setter form defers pool start-up to the
+ * first {@code getConnection()} call, so the application context still starts when the
+ * database is unreachable. That matches how the service behaved when it opened a single
+ * {@code DriverManager} connection, and keeps context-only tests from needing a database.
+ */
+@Configuration
+public class DataSourceConfig {
+
+    /** Name reported by Hikari in logs and JMX, to distinguish this pool in shared deployments. */
+    private static final String POOL_NAME = "viron-pool";
+
+    @Bean(destroyMethod = "close")
+    public DataSource dataSource(DbConfig dbConfig) {
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setPoolName(POOL_NAME);
+        dataSource.setJdbcUrl(dbConfig.getDbUrl());
+        dataSource.setUsername(dbConfig.getDbUsername());
+        dataSource.setPassword(dbConfig.getDbPassword());
+        return dataSource;
+    }
+}

--- a/src/main/java/preponderous/viron/database/DbInteractions.java
+++ b/src/main/java/preponderous/viron/database/DbInteractions.java
@@ -4,7 +4,6 @@
 package preponderous.viron.database;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -12,25 +11,42 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import javax.sql.DataSource;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.stereotype.Component;
-
-import preponderous.viron.config.DbConfig;
 
 /**
  * Postgres database interactions.
+ *
+ * <p>Every call borrows a connection from the pooled {@link DataSource} supplied by
+ * {@link preponderous.viron.config.DataSourceConfig} and returns it before the call ends, so
+ * concurrent requests never share one {@link Connection} (a {@code Connection} is not required
+ * to be thread-safe, and the single long-lived connection this class used to hold was shared by
+ * every request).
+ *
+ * <p>Connections are borrowed through {@link DataSourceUtils} rather than
+ * {@code DataSource.getConnection()} directly. Outside a transaction that behaves exactly like
+ * borrowing and returning a pooled connection; inside one, the connection already bound to the
+ * transaction is reused and its release is deferred to the transaction manager. That is what
+ * makes it possible to place transaction boundaries around the multi-statement write paths
+ * tracked in #194 without changing this class again.
+ *
+ * <p>A failure to obtain a connection at all (database down, credentials wrong, pool exhausted)
+ * surfaces as an unchecked
+ * {@link org.springframework.jdbc.CannotGetJdbcConnectionException} rather than an empty result,
+ * so an outage is reported as a 500 instead of being mistaken for missing data.
  */
 @Component
 @Slf4j
 public class DbInteractions {
-    private Connection connection;
-    private final DbConfig dbConfig;
+    private final DataSource dataSource;
 
     @Autowired
-    public DbInteractions(DbConfig dbConfig) {
-        this.dbConfig = dbConfig;
-        this.connection = connect();
+    public DbInteractions(DataSource dataSource) {
+        this.dataSource = dataSource;
     }
 
     /**
@@ -38,7 +54,7 @@ public class DbInteractions {
      *
      * <p>The query is run through a {@link PreparedStatement} so caller-supplied
      * values are bound as parameters rather than concatenated into SQL. The
-     * statement and result set are owned here and closed before returning, so no
+     * connection, statement and result set are owned here and released before returning, so no
      * JDBC resource ever reaches the caller.
      *
      * @param query  SQL with {@code ?} placeholders for each parameter
@@ -49,6 +65,7 @@ public class DbInteractions {
      */
     public <T> List<T> query(String query, RowMapper<T> mapper, Object... params) {
         List<T> results = new ArrayList<>();
+        Connection connection = DataSourceUtils.getConnection(dataSource);
         try (PreparedStatement statement = connection.prepareStatement(query)) {
             bindParameters(statement, params);
             try (ResultSet rs = statement.executeQuery()) {
@@ -60,6 +77,8 @@ public class DbInteractions {
             log.error("Error executing query: {}", e.getMessage());
             // Discard any partially mapped rows rather than reporting a truncated result.
             return new ArrayList<>();
+        } finally {
+            DataSourceUtils.releaseConnection(connection, dataSource);
         }
         return results;
     }
@@ -77,6 +96,7 @@ public class DbInteractions {
      * @return the mapped first row, or an empty {@link Optional} if there were no rows or the query failed
      */
     public <T> Optional<T> queryOne(String query, RowMapper<T> mapper, Object... params) {
+        Connection connection = DataSourceUtils.getConnection(dataSource);
         try (PreparedStatement statement = connection.prepareStatement(query)) {
             bindParameters(statement, params);
             try (ResultSet rs = statement.executeQuery()) {
@@ -86,6 +106,8 @@ public class DbInteractions {
             }
         } catch (SQLException e) {
             log.error("Error executing query: {}", e.getMessage());
+        } finally {
+            DataSourceUtils.releaseConnection(connection, dataSource);
         }
         return Optional.empty();
     }
@@ -94,18 +116,22 @@ public class DbInteractions {
      * Execute a parameterized INSERT/UPDATE/DELETE.
      *
      * <p>Run through a {@link PreparedStatement} (parameters bound, not concatenated)
-     * inside a try-with-resources so the statement is always closed.
+     * inside a try-with-resources so the statement is always closed, and the borrowed
+     * connection is always returned to the pool.
      *
      * @param query  SQL with {@code ?} placeholders for each parameter
      * @param params values to bind to the placeholders, in order
      * @return {@code true} if at least one row was affected, {@code false} otherwise (including on error)
      */
     public boolean update(String query, Object... params) {
+        Connection connection = DataSourceUtils.getConnection(dataSource);
         try (PreparedStatement statement = connection.prepareStatement(query)) {
             bindParameters(statement, params);
             return statement.executeUpdate() > 0;
         } catch (SQLException e) {
             log.error("Error executing update: {}", e.getMessage());
+        } finally {
+            DataSourceUtils.releaseConnection(connection, dataSource);
         }
         return false;
     }
@@ -115,26 +141,4 @@ public class DbInteractions {
             statement.setObject(i + 1, params[i]);
         }
     }
-
-    public void close() {
-        try {
-            connection.close();
-        } catch (SQLException e) {
-            log.error("Error closing connection: {}", e.getMessage());
-        }
-    }
-
-    /**
-    * Connect to the database.
-    * @return Connection
-    */
-    public Connection connect() {
-        try {
-            connection = DriverManager.getConnection(dbConfig.getDbUrl(), dbConfig.getDbUsername(), dbConfig.getDbPassword());
-        } catch (SQLException e) {
-            log.error("Error connecting to the database: {}", e.getMessage());
-        }
-        return connection;
-    }
-
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,12 @@ database.dbUrl=jdbc:postgresql://localhost:5432/postgres
 database.dbUsername=postgres
 database.dbPassword=postgres
 
+# Connections are pooled by HikariCP (see DataSourceConfig). Actuator would otherwise add a
+# database contributor to /actuator/health, which is left off so health stays a liveness signal
+# that does not go DOWN — and restart pods — during a database outage. Turn on where
+# /actuator/health is consumed as a readiness signal instead.
+management.health.db.enabled=false
+
 service.vironHost=http://localhost
 service.vironPort=9999
 

--- a/src/test/java/preponderous/viron/config/DataSourceConfigTest.java
+++ b/src/test/java/preponderous/viron/config/DataSourceConfigTest.java
@@ -1,0 +1,66 @@
+// Copyright (c) 2024 Preponderous Software
+// MIT License
+
+package preponderous.viron.config;
+
+import javax.sql.DataSource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the pooled {@link DataSource} introduced for #194: that it is built from
+ * {@link DbConfig}, that it does not contact the database until first use, and that it is the
+ * only {@link DataSource} in the context (so Spring Boot's auto-configured one has backed off).
+ */
+@SpringBootTest
+class DataSourceConfigTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    void dataSourceIsAPoolBuiltFromDbConfig() {
+        DbConfig config = new DbConfig();
+        config.setDbUrl("jdbc:h2:mem:viron_datasourceconfig");
+        config.setDbUsername("sa");
+        config.setDbPassword("secret");
+
+        HikariDataSource dataSource = (HikariDataSource) new DataSourceConfig().dataSource(config);
+        try {
+            assertThat(dataSource.getJdbcUrl()).isEqualTo("jdbc:h2:mem:viron_datasourceconfig");
+            assertThat(dataSource.getUsername()).isEqualTo("sa");
+            assertThat(dataSource.getPassword()).isEqualTo("secret");
+            assertThat(dataSource.getPoolName()).isEqualTo("viron-pool");
+        } finally {
+            dataSource.close();
+        }
+    }
+
+    // Pool start-up is deferred so the context still starts when the database is unreachable.
+    @Test
+    void poolIsNotStartedUntilFirstConnectionIsRequested() {
+        DbConfig config = new DbConfig();
+        config.setDbUrl("jdbc:h2:mem:viron_datasourceconfig_lazy");
+        config.setDbUsername("sa");
+        config.setDbPassword("");
+
+        HikariDataSource dataSource = (HikariDataSource) new DataSourceConfig().dataSource(config);
+        try {
+            assertThat(dataSource.getHikariPoolMXBean()).isNull();
+        } finally {
+            dataSource.close();
+        }
+    }
+
+    @Test
+    void contextExposesExactlyOnePooledDataSource() {
+        assertThat(applicationContext.getBeanNamesForType(DataSource.class)).hasSize(1);
+        assertThat(applicationContext.getBean(DataSource.class)).isInstanceOf(HikariDataSource.class);
+    }
+}

--- a/src/test/java/preponderous/viron/database/DbInteractionsTest.java
+++ b/src/test/java/preponderous/viron/database/DbInteractionsTest.java
@@ -1,21 +1,34 @@
 package preponderous.viron.database;
 
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import preponderous.viron.config.DataSourceConfig;
 import preponderous.viron.config.DbConfig;
 
+import javax.sql.DataSource;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Exercises {@link DbInteractions} against an in-memory H2 database to verify
- * parameter binding (#139), resource handling (#140), and the row-mapping
- * query API (#144). The application's real SQL is Postgres-specific; this test
- * uses its own neutral schema and only validates the generic query/update
- * mechanism.
+ * parameter binding (#139), resource handling (#140), the row-mapping
+ * query API (#144), and connection pooling (#194). The application's real SQL is
+ * Postgres-specific; this test uses its own neutral schema and only validates the
+ * generic query/update mechanism.
+ *
+ * <p>The {@link DataSource} is built by the production {@link DataSourceConfig} so the
+ * wiring under test is the wiring that ships.
  */
 public class DbInteractionsTest {
 
@@ -26,18 +39,21 @@ public class DbInteractionsTest {
     private static final RowMapper<Person> PERSON_MAPPER =
             rs -> new Person(rs.getInt("id"), rs.getString("name"));
 
+    private DataSource dataSource;
     private DbInteractions dbInteractions;
 
     @BeforeEach
     void setUp() {
-        DbConfig config = new DbConfig();
-        config.setDbUrl("jdbc:h2:mem:viron_dbinteractions;DB_CLOSE_DELAY=-1");
-        config.setDbUsername("sa");
-        config.setDbPassword("");
-        dbInteractions = new DbInteractions(config);
+        dataSource = new DataSourceConfig().dataSource(h2Config());
+        dbInteractions = new DbInteractions(dataSource);
 
         dbInteractions.update("DROP TABLE IF EXISTS person");
         dbInteractions.update("CREATE TABLE person (id INT PRIMARY KEY, name VARCHAR(255))");
+    }
+
+    @AfterEach
+    void tearDown() {
+        ((HikariDataSource) dataSource).close();
     }
 
     @Test
@@ -126,5 +142,69 @@ public class DbInteractionsTest {
     @Test
     void update_affectingNoRows_returnsFalse() {
         assertThat(dbInteractions.update("UPDATE person SET name = ? WHERE id = ?", "Nobody", 999)).isFalse();
+    }
+
+    // #194: every path must hand its connection back to the pool. A pool of one with a short
+    // acquisition timeout turns any leak — including one on an error path — into a failure on
+    // the very next call.
+    @Test
+    void everyPath_returnsItsConnectionToThePool() {
+        HikariDataSource singleConnectionPool = (HikariDataSource) new DataSourceConfig().dataSource(h2Config());
+        singleConnectionPool.setMaximumPoolSize(1);
+        singleConnectionPool.setConnectionTimeout(1000);
+
+        DbInteractions pooled = new DbInteractions(singleConnectionPool);
+        try {
+            for (int i = 0; i < 20; i++) {
+                int id = 100 + i;
+                assertThat(pooled.update("INSERT INTO person (id, name) VALUES (?, ?)", id, "Pooled" + id)).isTrue();
+                assertThat(pooled.queryOne("SELECT id, name FROM person WHERE id = ?", PERSON_MAPPER, id)).isPresent();
+                assertThat(pooled.query("SELECT id, name FROM person", PERSON_MAPPER)).isNotEmpty();
+
+                assertThat(pooled.update("UPDATE does_not_exist SET name = ?", "x")).isFalse();
+                assertThat(pooled.query("SELECT * FROM does_not_exist", PERSON_MAPPER)).isEmpty();
+                assertThat(pooled.queryOne("SELECT * FROM does_not_exist", PERSON_MAPPER)).isEmpty();
+            }
+        } finally {
+            singleConnectionPool.close();
+        }
+    }
+
+    // #194: concurrent callers each get their own connection. The previous design held one
+    // shared Connection on an application-scoped component, which JDBC does not require to be
+    // thread-safe.
+    @Test
+    void concurrentCallers_eachSeeTheirOwnWrite() throws Exception {
+        int threads = 8;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<Optional<Person>>> results = new ArrayList<>();
+
+        for (int i = 0; i < threads; i++) {
+            int id = 200 + i;
+            results.add(executor.submit(() -> {
+                start.await();
+                dbInteractions.update("INSERT INTO person (id, name) VALUES (?, ?)", id, "Concurrent" + id);
+                return dbInteractions.queryOne("SELECT id, name FROM person WHERE id = ?", PERSON_MAPPER, id);
+            }));
+        }
+        start.countDown();
+
+        try {
+            for (int i = 0; i < threads; i++) {
+                assertThat(results.get(i).get(30, TimeUnit.SECONDS))
+                        .contains(new Person(200 + i, "Concurrent" + (200 + i)));
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static DbConfig h2Config() {
+        DbConfig config = new DbConfig();
+        config.setDbUrl("jdbc:h2:mem:viron_dbinteractions;DB_CLOSE_DELAY=-1");
+        config.setDbUsername("sa");
+        config.setDbPassword("");
+        return config;
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -11,6 +11,10 @@ database.dbUrl=jdbc:postgresql://localhost:5432/postgres
 database.dbUsername=postgres
 database.dbPassword=postgres
 
+# Mirrors the runtime setting: no database contributor on /actuator/health, so
+# SecurityConfigTest's health check does not depend on a reachable database.
+management.health.db.enabled=false
+
 service.vironHost=http://localhost
 service.vironPort=9999
 

--- a/tickets.md
+++ b/tickets.md
@@ -263,7 +263,7 @@ Each ticket is designed to:
 **Scope:**
 - Verify springdoc-openapi-ui dependency is configured
 - Add OpenAPI annotations to controllers if needed
-- Test Swagger UI at `http://localhost:8080/swagger-ui.html`
+- Test Swagger UI at `http://localhost:9999/swagger-ui.html`
 - Compare generated spec with `docs/openapi/viron-api.json`
 - Update OpenAPI spec if implementation differs (but prefer spec-first)
 - Add API documentation section to README.md
@@ -325,7 +325,7 @@ Each ticket is designed to:
 
 **Acceptance Criteria:**
 - `docker compose up --build` starts app and database
-- Application is accessible at `http://localhost:8080`
+- Application is accessible at `http://localhost:9999`
 - Database persists data between restarts
 - README.md has clear setup instructions
 


### PR DESCRIPTION
## Summary

Two independent changes are carried here: the connection-management prerequisite from #194,
and the local-run configuration gaps found during this cycle's triage.

### Pooled database connections (prerequisite for #194)

- `DbInteractions` no longer opens a single `java.sql.Connection` in its constructor and holds
  it as state on an application-scoped `@Component`. Every concurrent request shared that one
  connection, which JDBC does not require to be thread-safe.
- A HikariCP pool is now built from `DbConfig` by the new `config/DataSourceConfig`, and
  `query`/`queryOne`/`update` each borrow and release a connection per call.
- Connections are borrowed through `DataSourceUtils` rather than `DataSource.getConnection()`.
  Outside a transaction this is plain borrow-and-return; inside one, the transaction-bound
  connection is reused. This is what allows `@Transactional` boundaries to be placed around the
  multi-statement write paths described in #194 without revisiting this class.
- The pool is constructed with setters rather than `new HikariDataSource(HikariConfig)`, so
  pool start-up is deferred to first use and the context still starts when the database is
  unreachable — matching the previous behaviour.
- Actuator's database health contributor is disabled (`management.health.db.enabled=false`) so
  `/actuator/health` keeps its current meaning. Adding a `DataSource` bean would otherwise have
  made health report DOWN during a database outage, which is a readiness signal rather than the
  liveness signal the endpoint is used as today. The property is commented so it can be turned
  on deliberately.
- The unused `connect()` and `close()` methods are removed; the pool is closed by Spring. No
  caller existed outside the class.

This is step 1 of #194 only, which the issue itself suggests splitting out. Steps 2 and 3
(transaction boundaries, and turning the duplicate-placement race into a 409) remain open, so
#194 is not closed here.

### Local-run configuration (#196, #197)

- `JWT_SECRET` is now passed through in `compose.yml` and defined in `sample.env`, alongside
  `JWT_ISSUER` and `JWT_ALGORITHM`. Without it, `app.jwt.secret=${JWT_SECRET}` fails to resolve
  and the service does not start, so the README's documented `docker-compose up --build` path
  was broken.
- The README's Getting Started section now states that the secret is required.
- The README's two references to `http://localhost:8080` are corrected to `9999`, matching
  `server.port` and the port compose publishes.
- The README's Tech Stack entry records HikariCP pooling.

## Test plan

- [ ] `./mvnw compile -B` — run by CI; `java`/`mvn` are unavailable in the environment this
      change was authored in, so CI is the authoritative signal.
- [ ] `./mvnw test -B` — run by CI.
- New `DbInteractionsTest` cases cover connection release on every path (a pool of one with a
  short acquisition timeout, exercised across success and error paths) and concurrent callers
  each completing their own write.
- New `DataSourceConfigTest` covers construction from `DbConfig`, deferred pool start-up, and
  the context exposing exactly one pooled `DataSource` (so Spring Boot's auto-configured one
  has backed off).
- `pytest` was not run: the Python SDK is untouched, since no endpoint URL, request shape or
  response shape changed.

Closes #196.
Closes #197.

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->
