### PR TITLE
build: raise the pytest floor and cover the Python client in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,30 @@ jobs:
 
       - name: Run tests
         run: ./mvnw test -B
+
+  python-client:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # The oldest interpreter the client claims to support and a current
+        # one, so syntax or typing that only newer releases accept is caught.
+        python-version: [ '3.8', '3.12' ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run tests
+        run: python -m pytest

--- a/README.md
+++ b/README.md
@@ -156,17 +156,19 @@ or refer to the `docs/openapi/viron-api.json` file.
 Run all Java unit and integration tests:  
 mvn test
 
-Run the Python client tests (requires Python 3.8+, `requests`, and pytest 7 or newer):  
+Install the Python client's dependencies (requires Python 3.8+):  
+pip install -r requirements.txt
+
+Run the Python client tests:  
 pytest
 
 `pytest.ini` puts the repository root on the path, so the client is imported the same way
 from tests as it is from application code (`src.main.python.preponderous.viron...`). The
-`pythonpath` setting it uses arrived in pytest 7.0, so the pytest 6.2.4 pinned by
-`requirements.txt` ignores it and collection fails; install a newer pytest until that pin is
-raised.
+`pythonpath` setting it uses arrived in pytest 7.0, which is why `requirements.txt` asks for
+that release or newer.
 
-Note that CI runs the Java build and tests only — Python client changes are not covered there
-and must be checked locally.
+CI runs both suites: the Java build and tests, and the Python client tests on Python 3.8 and
+3.12.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,10 @@
-pytest==6.2.4
-requests==2.25.1
+# Dependencies of the Python client under src/main/python and its pytest suite.
+# Floors rather than exact pins: this file doubles as the client's declared
+# dependency surface, and exact pins there fight with the applications that
+# consume it.
+#
+# pytest 7.0 is the release that introduced the `pythonpath` ini setting that
+# pytest.ini relies on for imports; anything older ignores it and collection
+# fails.
+pytest>=7.0
+requests>=2.32.0


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- `requirements.txt` asked for pytest 6.2.4, a release that predates the `pythonpath` ini setting `pytest.ini` depends on. Anyone installing from that file was returned to the collection failure fixed in #201, which the README had been papering over with a warning. The floor is raised to pytest 7.0.
- Both entries are expressed as floors rather than exact pins, because this file doubles as the declared dependency surface of the client under `src/main/python`, where exact pins fight with consuming applications. `requests` moves off 2.25.1 (December 2020) to 2.32.0 at the same time.
- A `python-client` job is added to `.github/workflows/ci.yml`. It installs `requirements.txt` and runs `pytest`, so the 107 tests under `src/test/python` are exercised on every push and pull request instead of by hand.
- The matrix covers Python 3.8 — the oldest interpreter the README claims — and 3.12. That shape is what would have caught the builtin generic annotation fixed in #204, which was invisible to CI at the time.
- The README's testing section is updated: the stopgap warning about the stale pin is removed, and the note that CI covers the Java build alone no longer holds.

## Test plan

- [x] `pytest` — 107 passed locally (Python 3.10.12, pytest 9.1.1)
- [x] No Java sources were touched by this change, so `./mvnw test -B` is left to the `build` job on this branch for its authoritative signal
- [x] The client suite mocks `requests.get`/`post`/`patch`/`delete` throughout, so the version bump is not exercised by test behaviour
- [x] The client and its tests were checked for PEP 585 builtin generics and PEP 604 unions, of which none remain, so the 3.8 leg is expected to be green

Closes #206
Closes #207

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).