### PR TITLE
fix: settle the move collision check against concurrent moves

### DIFF
--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -51,8 +51,8 @@ Deliver a working, tested API that supports:
 - [x] `GET /api/v1/locations/{locationId}/occupied` – Report whether a location holds any entities.
 - [x] `GET /api/v1/locations/{locationId}/neighbors` – Retrieve the locations adjacent to a location within its grid.
 - [x] `PUT /api/v1/locations/{locationId}/entity/{entityId}` – Place an unplaced entity at a location (no-op when the entity is already there, conflict when it is placed elsewhere).
-- [x] `PUT /api/v1/locations/{locationId}/entity/{entityId}/move` – Move a placed entity to an adjacent, unoccupied location in the same grid.
-- [x] `DELETE /api/v1/locations/{locationId}/entity/{entityId}` – Remove an entity from a specific location.
+- [x] `PUT /api/v1/locations/{locationId}/entity/{entityId}/move` – Move a placed entity to an adjacent, unoccupied location in the same grid (concurrent moves into the same location are resolved in sequence, one of them taking effect and the rest reported as conflicts).
+- [x] `DELETE /api/v1/locations/{locationId}/entity/{entityId}` – Remove an entity from a specific location (not found when the entity is not placed there).
 - [x] `DELETE /api/v1/locations/entity/{entityId}` – Remove an entity from its current location.
 
 ---

--- a/docs/openapi/viron-api.json
+++ b/docs/openapi/viron-api.json
@@ -393,6 +393,7 @@
       },
       "delete": {
         "summary": "Remove entity from location",
+        "description": "Removes the entity placed at the location. An entity that is not placed there, whether it is placed elsewhere or not placed at all, is reported as not found.",
         "parameters": [
           { "$ref": "#/components/parameters/LocationIdParam" },
           { "$ref": "#/components/parameters/EntityIdParam" }
@@ -400,7 +401,7 @@
         "responses": {
           "204": { "description": "Entity removed" },
           "404": {
-            "description": "Location not found with that id",
+            "description": "No location with that id, or the entity is not placed at that location",
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
             }
@@ -411,6 +412,7 @@
     "/api/v1/locations/{locationId}/entity/{entityId}/move": {
       "put": {
         "summary": "Move an entity to an adjacent, unoccupied location in the same grid",
+        "description": "Moves a placed entity to an adjacent, unoccupied location in the same grid. The target is held against other moves for the duration of the request, so two moves into the same empty location are resolved in sequence: one takes effect and the other is answered as a conflict.",
         "parameters": [
           { "$ref": "#/components/parameters/LocationIdParam" },
           { "$ref": "#/components/parameters/EntityIdParam" }
@@ -430,7 +432,7 @@
             }
           },
           "409": {
-            "description": "Target location is already occupied",
+            "description": "Target location is already occupied, including when a concurrent move reached it first",
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
             }

--- a/src/main/java/preponderous/viron/controllers/LocationController.java
+++ b/src/main/java/preponderous/viron/controllers/LocationController.java
@@ -129,16 +129,25 @@ public class LocationController {
      * it is placed elsewhere or not placed at all — is a request naming something that does not
      * exist, answered as such rather than as a server fault (#210); the sibling
      * {@link #removeEntityFromCurrentLocation(int)} already answers the equivalent case the same way.
+     *
+     * <p>The placement is locked before it is read, and the read and the delete run in one
+     * transaction, so that two removals of the same placement at once are resolved in sequence.
+     * Without the lock the second of them would find the row already gone by the time it wrote,
+     * and be answered with the server fault this endpoint has just stopped reporting.
      */
     @DeleteMapping("/{locationId}/entity/{entityId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Transactional
     public void removeEntityFromLocation(@PathVariable("entityId") @Min(1) int entityId, @PathVariable("locationId") @Min(1) int locationId) {
         if (locationRepository.findById(locationId).isEmpty()) {
             throw new NotFoundException("Location not found with id: " + locationId);
         }
+        if (!locationRepository.lockPlacementOfEntity(entityId)) {
+            throw entityNotAtLocation(entityId, locationId);
+        }
         Optional<Location> placement = locationRepository.findByEntityId(entityId);
         if (placement.isEmpty() || placement.get().getLocationId() != locationId) {
-            throw new NotFoundException("Entity " + entityId + " is not at location " + locationId);
+            throw entityNotAtLocation(entityId, locationId);
         }
         if (!locationRepository.removeEntityFromLocation(entityId, locationId)) {
             throw new ServiceException("Failed to remove entity " + entityId + " from location " + locationId);
@@ -241,6 +250,10 @@ public class LocationController {
 
     private static NotFoundException entityNotPlaced(int entityId) {
         return new NotFoundException("Entity " + entityId + " is not placed at any location");
+    }
+
+    private static NotFoundException entityNotAtLocation(int entityId, int locationId) {
+        return new NotFoundException("Entity " + entityId + " is not at location " + locationId);
     }
 
     /** True if {@code a} and {@code b} are within one grid cell of each other (Chebyshev distance 1), including diagonals. */

--- a/src/main/java/preponderous/viron/controllers/LocationController.java
+++ b/src/main/java/preponderous/viron/controllers/LocationController.java
@@ -200,14 +200,22 @@ public class LocationController {
      * an invariant of the data. The target's row is therefore locked before its occupancy is read,
      * and the lock is held to the end of the transaction, so a second move into the same location
      * waits and then reads the placement the first one committed.
+     *
+     * <p>The entity's own placement is locked first, before anything is read, for two reasons: it
+     * keeps the position the checks below are made against from moving underneath them, and it is
+     * the order {@code deleteEnvironment} takes the same two locks in, so a move and a cascade
+     * delete cannot end up waiting on each other in a cycle.
      */
     @PutMapping("/{locationId}/entity/{entityId}/move")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Transactional
     public void moveEntityToLocation(@PathVariable("entityId") @Min(1) int entityId,
                                      @PathVariable("locationId") @Min(1) int locationId) {
+        if (!locationRepository.lockPlacementOfEntity(entityId)) {
+            throw entityNotPlaced(entityId);
+        }
         Location current = locationRepository.findByEntityId(entityId)
-                .orElseThrow(() -> new NotFoundException("Entity " + entityId + " is not placed at any location"));
+                .orElseThrow(() -> entityNotPlaced(entityId));
         Location target = locationRepository.findById(locationId)
                 .orElseThrow(() -> new NotFoundException("Location not found with id: " + locationId));
         Optional<Integer> currentGrid = locationRepository.getGridIdOfLocation(current.getLocationId());
@@ -229,6 +237,10 @@ public class LocationController {
         if (!locationRepository.moveEntityToLocation(entityId, locationId)) {
             throw new ServiceException("Failed to move entity " + entityId + " to location " + locationId);
         }
+    }
+
+    private static NotFoundException entityNotPlaced(int entityId) {
+        return new NotFoundException("Entity " + entityId + " is not placed at any location");
     }
 
     /** True if {@code a} and {@code b} are within one grid cell of each other (Chebyshev distance 1), including diagonals. */

--- a/src/main/java/preponderous/viron/controllers/LocationController.java
+++ b/src/main/java/preponderous/viron/controllers/LocationController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import preponderous.viron.dto.LocationDto;
@@ -123,11 +124,21 @@ public class LocationController {
                 + placement.getLocationId());
     }
 
+    /**
+     * Removes the entity placed at {@code locationId}. An entity that is not placed there — whether
+     * it is placed elsewhere or not placed at all — is a request naming something that does not
+     * exist, answered as such rather than as a server fault (#210); the sibling
+     * {@link #removeEntityFromCurrentLocation(int)} already answers the equivalent case the same way.
+     */
     @DeleteMapping("/{locationId}/entity/{entityId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeEntityFromLocation(@PathVariable("entityId") @Min(1) int entityId, @PathVariable("locationId") @Min(1) int locationId) {
         if (locationRepository.findById(locationId).isEmpty()) {
             throw new NotFoundException("Location not found with id: " + locationId);
+        }
+        Optional<Location> placement = locationRepository.findByEntityId(entityId);
+        if (placement.isEmpty() || placement.get().getLocationId() != locationId) {
+            throw new NotFoundException("Entity " + entityId + " is not at location " + locationId);
         }
         if (!locationRepository.removeEntityFromLocation(entityId, locationId)) {
             throw new ServiceException("Failed to remove entity " + entityId + " from location " + locationId);
@@ -179,9 +190,20 @@ public class LocationController {
      * the entity is placed, the target exists and is in the same grid, is adjacent to the
      * entity's current location, and is not already occupied (collision). The transition
      * itself is a single atomic update.
+     *
+     * <p>The collision check is not something the read alone can decide: two moves into the same
+     * empty location would both read it empty and both write, leaving the target holding two
+     * entities that the 409 above claims to prevent (#203). Nothing in the schema settles this the
+     * way the primary key settles {@link #addEntityToLocation(int, int)} — a location is permitted
+     * to hold several entities, and {@code addEntityToLocation} places one without consulting
+     * occupancy at all, so "at most one entity per location" is this endpoint's rule rather than
+     * an invariant of the data. The target's row is therefore locked before its occupancy is read,
+     * and the lock is held to the end of the transaction, so a second move into the same location
+     * waits and then reads the placement the first one committed.
      */
     @PutMapping("/{locationId}/entity/{entityId}/move")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Transactional
     public void moveEntityToLocation(@PathVariable("entityId") @Min(1) int entityId,
                                      @PathVariable("locationId") @Min(1) int locationId) {
         Location current = locationRepository.findByEntityId(entityId)
@@ -197,6 +219,9 @@ public class LocationController {
         if (!isAdjacent(current, target)) {
             throw new InvalidRequestException(
                     "Target location " + locationId + " is not adjacent to entity " + entityId + "'s current location");
+        }
+        if (!locationRepository.lockLocation(locationId)) {
+            throw new NotFoundException("Location not found with id: " + locationId);
         }
         if (!locationRepository.getEntityIdsAtLocation(locationId).isEmpty()) {
             throw new ConflictException("Target location " + locationId + " is already occupied");

--- a/src/main/java/preponderous/viron/database/DbInteractions.java
+++ b/src/main/java/preponderous/viron/database/DbInteractions.java
@@ -15,6 +15,7 @@ import javax.sql.DataSource;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.stereotype.Component;
@@ -115,6 +116,37 @@ public class DbInteractions {
             DataSourceUtils.releaseConnection(connection, dataSource);
         }
         return Optional.empty();
+    }
+
+    /**
+     * Execute a parameterized {@code SELECT ... FOR UPDATE}, reporting a failure to take the lock
+     * to the caller instead of flattening it into "no such row".
+     *
+     * <p>The distinction matters here in a way it does not for
+     * {@link #queryOne(String, RowMapper, Object...)}: a caller locks a row in order to decide
+     * something on the strength of holding it, and every reason the statement can fail — a lock
+     * timeout, a deadlock the database broke, a serialization failure — is a reason to retry or to
+     * report a fault, not evidence that the row is absent. Answering "not found" for a row that
+     * exists but could not be locked would tell the client the resource is gone.
+     *
+     * @param query  a locking SELECT with {@code ?} placeholders for each parameter
+     * @param params values to bind to the placeholders, in order
+     * @return {@code true} if the statement matched, and therefore locked, a row
+     * @throws org.springframework.dao.CannotAcquireLockException if the statement failed
+     */
+    public boolean lock(String query, Object... params) {
+        Connection connection = DataSourceUtils.getConnection(dataSource);
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            bindParameters(statement, params);
+            try (ResultSet rs = statement.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            log.error("Error taking lock: {}", e.getMessage());
+            throw new CannotAcquireLockException("Could not take lock: " + e.getMessage(), e);
+        } finally {
+            DataSourceUtils.releaseConnection(connection, dataSource);
+        }
     }
 
     /**

--- a/src/main/java/preponderous/viron/repositories/LocationRepository.java
+++ b/src/main/java/preponderous/viron/repositories/LocationRepository.java
@@ -32,6 +32,22 @@ public interface LocationRepository {
     Optional<Integer> getGridIdOfLocation(int locationId);
 
     /**
+     * Takes an exclusive row lock on an entity's placement, held until the surrounding transaction
+     * ends.
+     *
+     * <p>Callers that lock both a placement and a location take this lock first, because that is
+     * the order the environment cascade delete acquires the same two — it clears
+     * {@code entity_location} before deleting the locations — and two paths that take the same
+     * locks in opposite orders can wait on each other in a cycle.
+     *
+     * <p>Only meaningful inside a transaction, for the reason given on {@link #lockLocation(int)}.
+     *
+     * @return {@code true} if the entity is placed and its placement is now locked, {@code false}
+     *         if it is not placed anywhere
+     */
+    boolean lockPlacementOfEntity(int entityId);
+
+    /**
      * Takes an exclusive row lock on a location, held until the surrounding transaction ends.
      *
      * <p>The lock is on the location itself rather than on whatever happens to occupy it, because

--- a/src/main/java/preponderous/viron/repositories/LocationRepository.java
+++ b/src/main/java/preponderous/viron/repositories/LocationRepository.java
@@ -31,6 +31,23 @@ public interface LocationRepository {
     /** The grid a location belongs to, if any. */
     Optional<Integer> getGridIdOfLocation(int locationId);
 
+    /**
+     * Takes an exclusive row lock on a location, held until the surrounding transaction ends.
+     *
+     * <p>The lock is on the location itself rather than on whatever happens to occupy it, because
+     * a location that is empty has no occupancy rows to lock and emptiness is exactly the state a
+     * collision check depends on (#203). Callers that read occupancy and then write on the
+     * strength of that read take this lock first, so any other caller doing the same against the
+     * same location waits rather than reading the same stale emptiness.
+     *
+     * <p>Only meaningful inside a transaction: without one the lock is released as soon as the
+     * statement ends, which is before the caller can act on what it read.
+     *
+     * @return {@code true} if the location exists and is now locked, {@code false} if there is no
+     *         such location
+     */
+    boolean lockLocation(int locationId);
+
     /** Atomically moves an entity's current placement to the target location. */
     boolean moveEntityToLocation(int entityId, int targetLocationId);
 }

--- a/src/main/java/preponderous/viron/repositories/LocationRepository.java
+++ b/src/main/java/preponderous/viron/repositories/LocationRepository.java
@@ -44,6 +44,9 @@ public interface LocationRepository {
      *
      * @return {@code true} if the entity is placed and its placement is now locked, {@code false}
      *         if it is not placed anywhere
+     * @throws org.springframework.dao.CannotAcquireLockException if the lock could not be taken —
+     *         a row that exists but is unavailable is not the same as a row that is absent, so
+     *         this is reported rather than returned as {@code false}
      */
     boolean lockPlacementOfEntity(int entityId);
 
@@ -61,6 +64,8 @@ public interface LocationRepository {
      *
      * @return {@code true} if the location exists and is now locked, {@code false} if there is no
      *         such location
+     * @throws org.springframework.dao.CannotAcquireLockException if the lock could not be taken,
+     *         for the reason given on {@link #lockPlacementOfEntity(int)}
      */
     boolean lockLocation(int locationId);
 

--- a/src/main/java/preponderous/viron/repositories/LocationRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/LocationRepositoryImpl.java
@@ -105,6 +105,12 @@ public class LocationRepositoryImpl implements LocationRepository {
     }
 
     @Override
+    public boolean lockPlacementOfEntity(int entityId) {
+        String query = "SELECT entity_id FROM viron.entity_location WHERE entity_id = ? FOR UPDATE";
+        return dbInteractions.queryOne(query, rs -> rs.getInt("entity_id"), entityId).isPresent();
+    }
+
+    @Override
     public boolean lockLocation(int locationId) {
         String query = "SELECT location_id FROM viron.location WHERE location_id = ? FOR UPDATE";
         return dbInteractions.queryOne(query, rs -> rs.getInt("location_id"), locationId).isPresent();

--- a/src/main/java/preponderous/viron/repositories/LocationRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/LocationRepositoryImpl.java
@@ -105,6 +105,12 @@ public class LocationRepositoryImpl implements LocationRepository {
     }
 
     @Override
+    public boolean lockLocation(int locationId) {
+        String query = "SELECT location_id FROM viron.location WHERE location_id = ? FOR UPDATE";
+        return dbInteractions.queryOne(query, rs -> rs.getInt("location_id"), locationId).isPresent();
+    }
+
+    @Override
     public boolean moveEntityToLocation(int entityId, int targetLocationId) {
         // Single atomic statement: re-point the entity's existing placement to the target.
         String query = "UPDATE viron.entity_location SET location_id = ? WHERE entity_id = ?";

--- a/src/main/java/preponderous/viron/repositories/LocationRepositoryImpl.java
+++ b/src/main/java/preponderous/viron/repositories/LocationRepositoryImpl.java
@@ -107,13 +107,13 @@ public class LocationRepositoryImpl implements LocationRepository {
     @Override
     public boolean lockPlacementOfEntity(int entityId) {
         String query = "SELECT entity_id FROM viron.entity_location WHERE entity_id = ? FOR UPDATE";
-        return dbInteractions.queryOne(query, rs -> rs.getInt("entity_id"), entityId).isPresent();
+        return dbInteractions.lock(query, entityId);
     }
 
     @Override
     public boolean lockLocation(int locationId) {
         String query = "SELECT location_id FROM viron.location WHERE location_id = ? FOR UPDATE";
-        return dbInteractions.queryOne(query, rs -> rs.getInt("location_id"), locationId).isPresent();
+        return dbInteractions.lock(query, locationId);
     }
 
     @Override

--- a/src/main/python/preponderous/viron/services/locationService.py
+++ b/src/main/python/preponderous/viron/services/locationService.py
@@ -68,7 +68,9 @@ class LocationService:
     def remove_entity_from_location(self, entity_id: int, location_id: int) -> None:
         response = requests.delete(f"{self.get_base_url()}/{location_id}/entity/{entity_id}", headers=self.get_auth_headers())
         if response.status_code == 404:
-            raise Exception("Location or entity not found")
+            # The service answers 404 both for a location that does not exist and for an entity
+            # that is not placed at it, so neither can be named on its own here.
+            raise Exception(f"No location {location_id} holding entity {entity_id}")
         response.raise_for_status()
 
     def remove_entity_from_current_location(self, entity_id: int) -> None:

--- a/src/test/java/preponderous/viron/config/TransactionBoundaryWiringTest.java
+++ b/src/test/java/preponderous/viron/config/TransactionBoundaryWiringTest.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.interceptor.TransactionAttributeSource;
 import preponderous.viron.controllers.EntityController;
 import preponderous.viron.controllers.EnvironmentController;
+import preponderous.viron.controllers.LocationController;
 import preponderous.viron.factories.EnvironmentFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,6 +54,16 @@ class TransactionBoundaryWiringTest {
     @Test
     void entityDeleteRunsInATransaction() {
         assertTransactional(EntityController.class, "deleteEntity", int.class);
+    }
+
+    /**
+     * The move's collision check holds a lock on the target from the moment it is read until the
+     * move is written (#203), and a lock only outlives the statement that took it inside a
+     * transaction.
+     */
+    @Test
+    void entityMoveRunsInATransaction() {
+        assertTransactional(LocationController.class, "moveEntityToLocation", int.class, int.class);
     }
 
     @Test

--- a/src/test/java/preponderous/viron/config/TransactionBoundaryWiringTest.java
+++ b/src/test/java/preponderous/viron/config/TransactionBoundaryWiringTest.java
@@ -66,6 +66,15 @@ class TransactionBoundaryWiringTest {
         assertTransactional(LocationController.class, "moveEntityToLocation", int.class, int.class);
     }
 
+    /**
+     * The removal locks the placement it is about to delete (#210), which is only held past the
+     * locking statement inside a transaction.
+     */
+    @Test
+    void entityRemovalFromALocationRunsInATransaction() {
+        assertTransactional(LocationController.class, "removeEntityFromLocation", int.class, int.class);
+    }
+
     @Test
     void environmentCreationRunsInATransaction() {
         assertTransactional(EnvironmentFactory.class, "createEnvironment",

--- a/src/test/java/preponderous/viron/controllers/ConcurrentMoveTest.java
+++ b/src/test/java/preponderous/viron/controllers/ConcurrentMoveTest.java
@@ -1,0 +1,208 @@
+// Copyright (c) 2024 Preponderous Software
+// MIT License
+
+package preponderous.viron.controllers;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import preponderous.viron.config.DataSourceConfig;
+import preponderous.viron.config.DbConfig;
+import preponderous.viron.database.DbInteractions;
+import preponderous.viron.exceptions.ConflictException;
+import preponderous.viron.mappers.LocationMapperImpl;
+import preponderous.viron.repositories.EntityRepositoryImpl;
+import preponderous.viron.repositories.LocationRepositoryImpl;
+
+import javax.sql.DataSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises the concurrent path through
+ * {@link LocationController#moveEntityToLocation(int, int)} (#203): two entities standing either
+ * side of the same empty location both move into it at once, and the collision the endpoint's 409
+ * exists to prevent has to be prevented rather than merely reported.
+ *
+ * <p>Nothing in the schema settles this on its own, unlike the placement race in
+ * {@link ConcurrentPlacementTest}: a location may hold several entities as far as the tables are
+ * concerned. What settles it is the lock the move takes on the target row, which only outlives
+ * the statement that took it inside a transaction — so the controller is driven through a
+ * {@link TransactionTemplate} here, standing in for the proxy that applies its
+ * {@code @Transactional} at runtime. That the annotation is genuinely applied is asserted
+ * separately, in {@code preponderous.viron.config.TransactionBoundaryWiringTest}.
+ *
+ * <p>The interleaving is forced rather than hoped for: {@link LockRacer} holds both requests at a
+ * barrier immediately before they reach for the lock, so they contend for it instead of arriving
+ * one after the other.
+ */
+class ConcurrentMoveTest {
+
+    private static final int LEFT_ENTITY_ID = 1;
+    private static final int RIGHT_ENTITY_ID = 2;
+    private static final int LEFT_LOCATION_ID = 1;
+    private static final int TARGET_LOCATION_ID = 2;
+    private static final int RIGHT_LOCATION_ID = 3;
+    private static final int GRID_ID = 1;
+    private static final int TIMEOUT_SECONDS = 30;
+
+    private DataSource dataSource;
+    private DbInteractions dbInteractions;
+
+    @BeforeEach
+    void setUp() {
+        dataSource = new DataSourceConfig().dataSource(h2Config());
+        dbInteractions = new DbInteractions(dataSource);
+
+        dbInteractions.update("DROP TABLE IF EXISTS viron.entity_location");
+        dbInteractions.update("DROP TABLE IF EXISTS viron.location_grid");
+        dbInteractions.update("DROP TABLE IF EXISTS viron.entity");
+        dbInteractions.update("DROP TABLE IF EXISTS viron.location");
+        dbInteractions.update("CREATE SCHEMA IF NOT EXISTS viron");
+        dbInteractions.update(
+                "CREATE TABLE viron.entity (entity_id INT PRIMARY KEY, name VARCHAR(255), creation_date VARCHAR(255))");
+        dbInteractions.update("CREATE TABLE viron.location (location_id INT PRIMARY KEY, x INT, y INT)");
+        dbInteractions.update("CREATE TABLE viron.location_grid ("
+                + "location_id INT NOT NULL, grid_id INT NOT NULL, PRIMARY KEY (location_id), "
+                + "FOREIGN KEY (location_id) REFERENCES viron.location(location_id))");
+        dbInteractions.update("CREATE TABLE viron.entity_location ("
+                + "entity_id INT NOT NULL, location_id INT NOT NULL, PRIMARY KEY (entity_id), "
+                + "FOREIGN KEY (entity_id) REFERENCES viron.entity(entity_id), "
+                + "FOREIGN KEY (location_id) REFERENCES viron.location(location_id))");
+
+        // Three locations in a row, so the middle one is adjacent to both of the others.
+        for (int locationId = LEFT_LOCATION_ID; locationId <= RIGHT_LOCATION_ID; locationId++) {
+            dbInteractions.update("INSERT INTO viron.location (location_id, x, y) VALUES (?, ?, ?)",
+                    locationId, locationId, 0);
+            dbInteractions.update("INSERT INTO viron.location_grid (location_id, grid_id) VALUES (?, ?)",
+                    locationId, GRID_ID);
+        }
+        placeEntity(LEFT_ENTITY_ID, "Alice", LEFT_LOCATION_ID);
+        placeEntity(RIGHT_ENTITY_ID, "Bob", RIGHT_LOCATION_ID);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ((HikariDataSource) dataSource).close();
+    }
+
+    /**
+     * Both entities may move into the empty location between them, but only one of them may end
+     * up there. The other is told the target is occupied and is left where it started, which is
+     * the same pair of outcomes the two requests would have got had they arrived in sequence.
+     */
+    @Test
+    void concurrentMovesIntoTheSameEmptyLocation_leaveOneEntityThere_andReportTheLoserAsAConflict()
+            throws Exception {
+        List<Throwable> outcomes = moveConcurrently();
+
+        assertThat(entityIdsAt(TARGET_LOCATION_ID)).hasSize(1);
+
+        int winner = entityIdsAt(TARGET_LOCATION_ID).get(0);
+        int loser = winner == LEFT_ENTITY_ID ? RIGHT_ENTITY_ID : LEFT_ENTITY_ID;
+        int loserStartingLocation = loser == LEFT_ENTITY_ID ? LEFT_LOCATION_ID : RIGHT_LOCATION_ID;
+        assertThat(entityIdsAt(loserStartingLocation)).containsExactly(loser);
+
+        List<Throwable> failures = outcomes.stream().filter(outcome -> outcome != null).toList();
+        assertThat(failures).hasSize(1);
+        assertThat(failures.get(0))
+                .isInstanceOf(ConflictException.class)
+                .hasMessage("Target location " + TARGET_LOCATION_ID + " is already occupied");
+    }
+
+    /**
+     * Runs both moves at once, each in its own transaction, and returns the exception each ended
+     * with or {@code null} where it succeeded.
+     */
+    private List<Throwable> moveConcurrently() throws Exception {
+        CyclicBarrier beforeLock = new CyclicBarrier(2);
+        LocationController controller = new LocationController(
+                new LockRacer(dbInteractions, beforeLock),
+                new EntityRepositoryImpl(dbInteractions),
+                new LocationMapperImpl());
+        TransactionTemplate transactionTemplate =
+                new TransactionTemplate(new DataSourceTransactionManager(dataSource));
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        List<Future<Throwable>> futures = new ArrayList<>();
+        for (int entityId : new int[] {LEFT_ENTITY_ID, RIGHT_ENTITY_ID}) {
+            futures.add(executor.submit(() -> {
+                try {
+                    transactionTemplate.executeWithoutResult(
+                            status -> controller.moveEntityToLocation(entityId, TARGET_LOCATION_ID));
+                    return null;
+                } catch (Throwable t) {
+                    return t;
+                }
+            }));
+        }
+
+        try {
+            List<Throwable> outcomes = new ArrayList<>();
+            for (Future<Throwable> future : futures) {
+                outcomes.add(future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            }
+            return outcomes;
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private void placeEntity(int entityId, String name, int locationId) {
+        dbInteractions.update("INSERT INTO viron.entity (entity_id, name, creation_date) VALUES (?, ?, ?)",
+                entityId, name, "2026-01-01");
+        dbInteractions.update("INSERT INTO viron.entity_location (entity_id, location_id) VALUES (?, ?)",
+                entityId, locationId);
+    }
+
+    private List<Integer> entityIdsAt(int locationId) {
+        return dbInteractions.query("SELECT entity_id FROM viron.entity_location WHERE location_id = ?",
+                rs -> rs.getInt("entity_id"), locationId);
+    }
+
+    /**
+     * The real repository, with both requests held at a barrier immediately before the lock is
+     * taken. Releasing them together is what makes the contention certain instead of a matter of
+     * timing: without the barrier the first request tends to have committed long before the
+     * second reads the target's occupancy, and the race never occurs.
+     */
+    private static class LockRacer extends LocationRepositoryImpl {
+        private final CyclicBarrier beforeLock;
+
+        LockRacer(DbInteractions dbInteractions, CyclicBarrier beforeLock) {
+            super(dbInteractions);
+            this.beforeLock = beforeLock;
+        }
+
+        @Override
+        public boolean lockLocation(int locationId) {
+            try {
+                beforeLock.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                throw new IllegalStateException("Timed out waiting for the other move to reach the lock", e);
+            }
+            return super.lockLocation(locationId);
+        }
+    }
+
+    private static DbConfig h2Config() {
+        DbConfig config = new DbConfig();
+        // A lock timeout well above the time either transaction needs, so the request that waits
+        // for the other one waits rather than failing.
+        config.setDbUrl("jdbc:h2:mem:viron_concurrent_move;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000");
+        config.setDbUsername("sa");
+        config.setDbPassword("");
+        return config;
+    }
+}

--- a/src/test/java/preponderous/viron/controllers/LocationControllerTest.java
+++ b/src/test/java/preponderous/viron/controllers/LocationControllerTest.java
@@ -624,6 +624,7 @@ class LocationControllerTest {
 
     @Test
     void moveEntityToLocation_Success() throws Exception {
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(true);
         when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(5, 0, 0)));
         when(locationRepository.findById(9)).thenReturn(Optional.of(new Location(9, 1, 0)));
         when(locationRepository.getGridIdOfLocation(5)).thenReturn(Optional.of(3));
@@ -640,10 +641,13 @@ class LocationControllerTest {
 
     /**
      * The target's occupancy is only read once the target is locked, so that a concurrent move
-     * cannot claim it in between (#203).
+     * cannot claim it in between (#203). The entity's placement is locked before the target,
+     * matching the order the environment cascade delete takes the same two locks in — the reverse
+     * order would let a move and a delete wait on each other in a cycle.
      */
     @Test
     void moveEntityToLocation_LocksTheTargetBeforeReadingItsOccupancy() throws Exception {
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(true);
         when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(5, 0, 0)));
         when(locationRepository.findById(9)).thenReturn(Optional.of(new Location(9, 1, 0)));
         when(locationRepository.getGridIdOfLocation(5)).thenReturn(Optional.of(3));
@@ -656,6 +660,7 @@ class LocationControllerTest {
                 .andExpect(status().isNoContent());
 
         InOrder inOrder = inOrder(locationRepository);
+        inOrder.verify(locationRepository).lockPlacementOfEntity(1);
         inOrder.verify(locationRepository).lockLocation(9);
         inOrder.verify(locationRepository).getEntityIdsAtLocation(9);
         inOrder.verify(locationRepository).moveEntityToLocation(1, 9);
@@ -667,6 +672,7 @@ class LocationControllerTest {
      */
     @Test
     void moveEntityToLocation_TargetDeletedBeforeLockIsNotFound() throws Exception {
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(true);
         when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(5, 0, 0)));
         when(locationRepository.findById(9)).thenReturn(Optional.of(new Location(9, 1, 0)));
         when(locationRepository.getGridIdOfLocation(5)).thenReturn(Optional.of(3));
@@ -691,6 +697,7 @@ class LocationControllerTest {
 
     @Test
     void moveEntityToLocation_TargetNotFound() throws Exception {
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(true);
         when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(5, 0, 0)));
         when(locationRepository.findById(9)).thenReturn(Optional.empty());
 
@@ -701,6 +708,7 @@ class LocationControllerTest {
 
     @Test
     void moveEntityToLocation_DifferentGridIsBadRequest() throws Exception {
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(true);
         when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(5, 0, 0)));
         when(locationRepository.findById(9)).thenReturn(Optional.of(new Location(9, 1, 0)));
         when(locationRepository.getGridIdOfLocation(5)).thenReturn(Optional.of(3));
@@ -712,6 +720,7 @@ class LocationControllerTest {
 
     @Test
     void moveEntityToLocation_NotAdjacentIsBadRequest() throws Exception {
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(true);
         when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(5, 0, 0)));
         when(locationRepository.findById(9)).thenReturn(Optional.of(new Location(9, 5, 5)));
         when(locationRepository.getGridIdOfLocation(5)).thenReturn(Optional.of(3));
@@ -726,6 +735,7 @@ class LocationControllerTest {
 
     @Test
     void moveEntityToLocation_OccupiedTargetIsConflict() throws Exception {
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(true);
         when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(5, 0, 0)));
         when(locationRepository.findById(9)).thenReturn(Optional.of(new Location(9, 1, 0)));
         when(locationRepository.getGridIdOfLocation(5)).thenReturn(Optional.of(3));

--- a/src/test/java/preponderous/viron/controllers/LocationControllerTest.java
+++ b/src/test/java/preponderous/viron/controllers/LocationControllerTest.java
@@ -482,6 +482,7 @@ class LocationControllerTest {
     @Test
     void removeEntityFromLocation_Success() throws Exception {
         when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(true);
         when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(2, 10, 20)));
         when(locationRepository.removeEntityFromLocation(1, 2)).thenReturn(true);
 
@@ -495,6 +496,7 @@ class LocationControllerTest {
     @Test
     void removeEntityFromLocation_EntityPlacedElsewhereIsNotFound() throws Exception {
         when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(true);
         when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(7, 30, 40)));
 
         mockMvc.perform(delete("/api/v1/locations/2/entity/1"))
@@ -505,10 +507,32 @@ class LocationControllerTest {
         verify(locationRepository, never()).removeEntityFromLocation(anyInt(), anyInt());
     }
 
-    /** Neither is an entity that is not placed anywhere, or does not exist at all (#210). */
+    /**
+     * Neither is an entity that is not placed anywhere, or does not exist at all (#210). There is
+     * no placement row to lock, so the request is answered without reading any further.
+     */
     @Test
     void removeEntityFromLocation_UnplacedEntityIsNotFound() throws Exception {
         when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(false);
+
+        mockMvc.perform(delete("/api/v1/locations/2/entity/1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("Entity 1 is not at location 2"));
+
+        verify(locationRepository, never()).findByEntityId(anyInt());
+        verify(locationRepository, never()).removeEntityFromLocation(anyInt(), anyInt());
+    }
+
+    /**
+     * The placement was locked but names a different location than the one read a moment earlier,
+     * which is the same "not at that location" answer arrived at after the lock rather than before.
+     */
+    @Test
+    void removeEntityFromLocation_PlacementMovedBeforeTheLockIsNotFound() throws Exception {
+        when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(true);
         when(locationRepository.findByEntityId(1)).thenReturn(Optional.empty());
 
         mockMvc.perform(delete("/api/v1/locations/2/entity/1"))
@@ -532,6 +556,7 @@ class LocationControllerTest {
     @Test
     void removeEntityFromLocation_RepositoryThrowsException() throws Exception {
         when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(true);
         when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(2, 10, 20)));
         when(locationRepository.removeEntityFromLocation(1, 2)).thenThrow(new RuntimeException("Database error"));
 
@@ -686,8 +711,26 @@ class LocationControllerTest {
         verify(locationRepository, never()).moveEntityToLocation(anyInt(), anyInt());
     }
 
+    /** There is no placement row to lock, which is how an unplaced entity is recognised. */
     @Test
     void moveEntityToLocation_EntityNotPlaced() throws Exception {
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(false);
+
+        mockMvc.perform(put("/api/v1/locations/9/entity/1/move"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Entity 1 is not placed at any location"));
+
+        verify(locationRepository, never()).findByEntityId(anyInt());
+    }
+
+    /**
+     * The placement was locked but could not be read back. The foreign keys make that unreachable
+     * in practice, so the guard exists only so that an unreadable placement is reported as the
+     * absent placement it looks like rather than as a null dereference.
+     */
+    @Test
+    void moveEntityToLocation_LockedPlacementThatCannotBeReadIsNotFound() throws Exception {
+        when(locationRepository.lockPlacementOfEntity(1)).thenReturn(true);
         when(locationRepository.findByEntityId(1)).thenReturn(Optional.empty());
 
         mockMvc.perform(put("/api/v1/locations/9/entity/1/move"))

--- a/src/test/java/preponderous/viron/controllers/LocationControllerTest.java
+++ b/src/test/java/preponderous/viron/controllers/LocationControllerTest.java
@@ -1,6 +1,7 @@
 package preponderous.viron.controllers;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -9,7 +10,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.test.web.servlet.MockMvc;
-import preponderous.viron.config.DbConfig;
 import preponderous.viron.database.DbInteractions;
 import preponderous.viron.dto.LocationDto;
 import preponderous.viron.mappers.LocationMapper;
@@ -47,8 +47,9 @@ class LocationControllerTest {
     @MockBean
     private DbInteractions dbInteractions;
 
-    @MockBean
-    private DbConfig dbConfig;
+    // DbConfig is left real, unlike the collaborators above: the transaction boundary on
+    // moveEntityToLocation opens a connection from the pool DbConfig configures, and a mock would
+    // supply it a null JDBC URL.
 
     // --- GET /api/v1/locations ---
 
@@ -481,12 +482,41 @@ class LocationControllerTest {
     @Test
     void removeEntityFromLocation_Success() throws Exception {
         when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(2, 10, 20)));
         when(locationRepository.removeEntityFromLocation(1, 2)).thenReturn(true);
 
         mockMvc.perform(delete("/api/v1/locations/2/entity/1"))
                 .andExpect(status().isNoContent());
 
         verify(locationRepository).removeEntityFromLocation(1, 2);
+    }
+
+    /** An entity that is placed somewhere else is not at the location the request names (#210). */
+    @Test
+    void removeEntityFromLocation_EntityPlacedElsewhereIsNotFound() throws Exception {
+        when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(7, 30, 40)));
+
+        mockMvc.perform(delete("/api/v1/locations/2/entity/1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("Entity 1 is not at location 2"));
+
+        verify(locationRepository, never()).removeEntityFromLocation(anyInt(), anyInt());
+    }
+
+    /** Neither is an entity that is not placed anywhere, or does not exist at all (#210). */
+    @Test
+    void removeEntityFromLocation_UnplacedEntityIsNotFound() throws Exception {
+        when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.empty());
+
+        mockMvc.perform(delete("/api/v1/locations/2/entity/1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("Entity 1 is not at location 2"));
+
+        verify(locationRepository, never()).removeEntityFromLocation(anyInt(), anyInt());
     }
 
     @Test
@@ -502,6 +532,7 @@ class LocationControllerTest {
     @Test
     void removeEntityFromLocation_RepositoryThrowsException() throws Exception {
         when(locationRepository.findById(2)).thenReturn(Optional.of(new Location(2, 10, 20)));
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(2, 10, 20)));
         when(locationRepository.removeEntityFromLocation(1, 2)).thenThrow(new RuntimeException("Database error"));
 
         mockMvc.perform(delete("/api/v1/locations/2/entity/1"))
@@ -597,6 +628,7 @@ class LocationControllerTest {
         when(locationRepository.findById(9)).thenReturn(Optional.of(new Location(9, 1, 0)));
         when(locationRepository.getGridIdOfLocation(5)).thenReturn(Optional.of(3));
         when(locationRepository.getGridIdOfLocation(9)).thenReturn(Optional.of(3));
+        when(locationRepository.lockLocation(9)).thenReturn(true);
         when(locationRepository.getEntityIdsAtLocation(9)).thenReturn(Collections.emptyList());
         when(locationRepository.moveEntityToLocation(1, 9)).thenReturn(true);
 
@@ -604,6 +636,48 @@ class LocationControllerTest {
                 .andExpect(status().isNoContent());
 
         verify(locationRepository).moveEntityToLocation(1, 9);
+    }
+
+    /**
+     * The target's occupancy is only read once the target is locked, so that a concurrent move
+     * cannot claim it in between (#203).
+     */
+    @Test
+    void moveEntityToLocation_LocksTheTargetBeforeReadingItsOccupancy() throws Exception {
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(5, 0, 0)));
+        when(locationRepository.findById(9)).thenReturn(Optional.of(new Location(9, 1, 0)));
+        when(locationRepository.getGridIdOfLocation(5)).thenReturn(Optional.of(3));
+        when(locationRepository.getGridIdOfLocation(9)).thenReturn(Optional.of(3));
+        when(locationRepository.lockLocation(9)).thenReturn(true);
+        when(locationRepository.getEntityIdsAtLocation(9)).thenReturn(Collections.emptyList());
+        when(locationRepository.moveEntityToLocation(1, 9)).thenReturn(true);
+
+        mockMvc.perform(put("/api/v1/locations/9/entity/1/move"))
+                .andExpect(status().isNoContent());
+
+        InOrder inOrder = inOrder(locationRepository);
+        inOrder.verify(locationRepository).lockLocation(9);
+        inOrder.verify(locationRepository).getEntityIdsAtLocation(9);
+        inOrder.verify(locationRepository).moveEntityToLocation(1, 9);
+    }
+
+    /**
+     * A target that no longer exists by the time it is locked was deleted between the two reads;
+     * that is the same missing target the earlier check answers for, so it gets the same answer.
+     */
+    @Test
+    void moveEntityToLocation_TargetDeletedBeforeLockIsNotFound() throws Exception {
+        when(locationRepository.findByEntityId(1)).thenReturn(Optional.of(new Location(5, 0, 0)));
+        when(locationRepository.findById(9)).thenReturn(Optional.of(new Location(9, 1, 0)));
+        when(locationRepository.getGridIdOfLocation(5)).thenReturn(Optional.of(3));
+        when(locationRepository.getGridIdOfLocation(9)).thenReturn(Optional.of(3));
+        when(locationRepository.lockLocation(9)).thenReturn(false);
+
+        mockMvc.perform(put("/api/v1/locations/9/entity/1/move"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Location not found with id: 9"));
+
+        verify(locationRepository, never()).moveEntityToLocation(anyInt(), anyInt());
     }
 
     @Test
@@ -656,6 +730,7 @@ class LocationControllerTest {
         when(locationRepository.findById(9)).thenReturn(Optional.of(new Location(9, 1, 0)));
         when(locationRepository.getGridIdOfLocation(5)).thenReturn(Optional.of(3));
         when(locationRepository.getGridIdOfLocation(9)).thenReturn(Optional.of(3));
+        when(locationRepository.lockLocation(9)).thenReturn(true);
         when(locationRepository.getEntityIdsAtLocation(9)).thenReturn(List.of(99));
 
         mockMvc.perform(put("/api/v1/locations/9/entity/1/move"))

--- a/src/test/java/preponderous/viron/database/DbInteractionsTest.java
+++ b/src/test/java/preponderous/viron/database/DbInteractionsTest.java
@@ -4,6 +4,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DuplicateKeyException;
 import preponderous.viron.config.DataSourceConfig;
 import preponderous.viron.config.DbConfig;
@@ -259,6 +260,23 @@ public class DbInteractionsTest {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    // #203: a locking SELECT reports whether it matched a row, and reports a failure rather than
+    // flattening it into "no such row" — a caller that locks a row in order to decide something
+    // on the strength of holding it cannot tell the two apart otherwise.
+    @Test
+    void lock_reportsWhetherARowWasMatched() {
+        dbInteractions.update("INSERT INTO person (id, name) VALUES (?, ?)", 300, "Locked");
+
+        assertThat(dbInteractions.lock("SELECT id FROM person WHERE id = ? FOR UPDATE", 300)).isTrue();
+        assertThat(dbInteractions.lock("SELECT id FROM person WHERE id = ? FOR UPDATE", 301)).isFalse();
+    }
+
+    @Test
+    void lock_reportsAFailedStatementInsteadOfReturningFalse() {
+        assertThatThrownBy(() -> dbInteractions.lock("SELECT id FROM no_such_table WHERE id = ? FOR UPDATE", 1))
+                .isInstanceOf(CannotAcquireLockException.class);
     }
 
     private static DbConfig h2Config() {

--- a/src/test/java/preponderous/viron/repositories/LocationRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/LocationRepositoryImplTest.java
@@ -367,4 +367,32 @@ public class LocationRepositoryImplTest {
         assertThat(repository.moveEntityToLocation(4, 9)).isTrue();
         Mockito.verify(dbInteractions).update(query, 9, 4);
     }
+
+    // ---- lockLocation ----
+
+    private static final String LOCK_QUERY = "SELECT location_id FROM viron.location WHERE location_id = ? FOR UPDATE";
+
+    @Test
+    public void testLockLocation_ReturnsTrueWhenTheLocationExists() throws SQLException {
+        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(LOCK_QUERY), any(), eq(5)))
+                .thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(mockResultSet.next()).thenReturn(true);
+        Mockito.when(mockResultSet.getInt("location_id")).thenReturn(5);
+
+        LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
+
+        assertThat(repository.lockLocation(5)).isTrue();
+        Mockito.verify(dbInteractions).queryOne(eq(LOCK_QUERY), any(), eq(5));
+    }
+
+    @Test
+    public void testLockLocation_ReturnsFalseWhenThereIsNoSuchLocation() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(LOCK_QUERY), any(), eq(5)))
+                .thenReturn(Optional.empty());
+
+        LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
+
+        assertThat(repository.lockLocation(5)).isFalse();
+    }
 }

--- a/src/test/java/preponderous/viron/repositories/LocationRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/LocationRepositoryImplTest.java
@@ -368,6 +368,35 @@ public class LocationRepositoryImplTest {
         Mockito.verify(dbInteractions).update(query, 9, 4);
     }
 
+    // ---- lockPlacementOfEntity ----
+
+    private static final String PLACEMENT_LOCK_QUERY =
+            "SELECT entity_id FROM viron.entity_location WHERE entity_id = ? FOR UPDATE";
+
+    @Test
+    public void testLockPlacementOfEntity_ReturnsTrueWhenTheEntityIsPlaced() throws SQLException {
+        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(PLACEMENT_LOCK_QUERY), any(), eq(4)))
+                .thenAnswer(mapsFirstRow(mockResultSet));
+        Mockito.when(mockResultSet.next()).thenReturn(true);
+        Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(4);
+
+        LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
+
+        assertThat(repository.lockPlacementOfEntity(4)).isTrue();
+        Mockito.verify(dbInteractions).queryOne(eq(PLACEMENT_LOCK_QUERY), any(), eq(4));
+    }
+
+    @Test
+    public void testLockPlacementOfEntity_ReturnsFalseWhenTheEntityIsNotPlaced() {
+        Mockito.when(dbInteractions.<Integer>queryOne(eq(PLACEMENT_LOCK_QUERY), any(), eq(4)))
+                .thenReturn(Optional.empty());
+
+        LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
+
+        assertThat(repository.lockPlacementOfEntity(4)).isFalse();
+    }
+
     // ---- lockLocation ----
 
     private static final String LOCK_QUERY = "SELECT location_id FROM viron.location WHERE location_id = ? FOR UPDATE";

--- a/src/test/java/preponderous/viron/repositories/LocationRepositoryImplTest.java
+++ b/src/test/java/preponderous/viron/repositories/LocationRepositoryImplTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DuplicateKeyException;
 import preponderous.viron.database.DbInteractions;
 import preponderous.viron.models.Location;
@@ -374,27 +375,34 @@ public class LocationRepositoryImplTest {
             "SELECT entity_id FROM viron.entity_location WHERE entity_id = ? FOR UPDATE";
 
     @Test
-    public void testLockPlacementOfEntity_ReturnsTrueWhenTheEntityIsPlaced() throws SQLException {
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Integer>queryOne(eq(PLACEMENT_LOCK_QUERY), any(), eq(4)))
-                .thenAnswer(mapsFirstRow(mockResultSet));
-        Mockito.when(mockResultSet.next()).thenReturn(true);
-        Mockito.when(mockResultSet.getInt("entity_id")).thenReturn(4);
+    public void testLockPlacementOfEntity_ReturnsTrueWhenTheEntityIsPlaced() {
+        Mockito.when(dbInteractions.lock(PLACEMENT_LOCK_QUERY, 4)).thenReturn(true);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
         assertThat(repository.lockPlacementOfEntity(4)).isTrue();
-        Mockito.verify(dbInteractions).queryOne(eq(PLACEMENT_LOCK_QUERY), any(), eq(4));
+        Mockito.verify(dbInteractions).lock(PLACEMENT_LOCK_QUERY, 4);
     }
 
     @Test
     public void testLockPlacementOfEntity_ReturnsFalseWhenTheEntityIsNotPlaced() {
-        Mockito.when(dbInteractions.<Integer>queryOne(eq(PLACEMENT_LOCK_QUERY), any(), eq(4)))
-                .thenReturn(Optional.empty());
+        Mockito.when(dbInteractions.lock(PLACEMENT_LOCK_QUERY, 4)).thenReturn(false);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
         assertThat(repository.lockPlacementOfEntity(4)).isFalse();
+    }
+
+    /** A lock that could not be taken is reported, not mistaken for a placement that is absent. */
+    @Test
+    public void testLockPlacementOfEntity_PropagatesAFailureToTakeTheLock() {
+        Mockito.when(dbInteractions.lock(PLACEMENT_LOCK_QUERY, 4))
+                .thenThrow(new CannotAcquireLockException("lock timeout"));
+
+        LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
+
+        assertThatThrownBy(() -> repository.lockPlacementOfEntity(4))
+                .isInstanceOf(CannotAcquireLockException.class);
     }
 
     // ---- lockLocation ----
@@ -402,26 +410,33 @@ public class LocationRepositoryImplTest {
     private static final String LOCK_QUERY = "SELECT location_id FROM viron.location WHERE location_id = ? FOR UPDATE";
 
     @Test
-    public void testLockLocation_ReturnsTrueWhenTheLocationExists() throws SQLException {
-        ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-        Mockito.when(dbInteractions.<Integer>queryOne(eq(LOCK_QUERY), any(), eq(5)))
-                .thenAnswer(mapsFirstRow(mockResultSet));
-        Mockito.when(mockResultSet.next()).thenReturn(true);
-        Mockito.when(mockResultSet.getInt("location_id")).thenReturn(5);
+    public void testLockLocation_ReturnsTrueWhenTheLocationExists() {
+        Mockito.when(dbInteractions.lock(LOCK_QUERY, 5)).thenReturn(true);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
         assertThat(repository.lockLocation(5)).isTrue();
-        Mockito.verify(dbInteractions).queryOne(eq(LOCK_QUERY), any(), eq(5));
+        Mockito.verify(dbInteractions).lock(LOCK_QUERY, 5);
     }
 
     @Test
     public void testLockLocation_ReturnsFalseWhenThereIsNoSuchLocation() {
-        Mockito.when(dbInteractions.<Integer>queryOne(eq(LOCK_QUERY), any(), eq(5)))
-                .thenReturn(Optional.empty());
+        Mockito.when(dbInteractions.lock(LOCK_QUERY, 5)).thenReturn(false);
 
         LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
 
         assertThat(repository.lockLocation(5)).isFalse();
+    }
+
+    /** A lock that could not be taken is reported, not mistaken for a location that is absent. */
+    @Test
+    public void testLockLocation_PropagatesAFailureToTakeTheLock() {
+        Mockito.when(dbInteractions.lock(LOCK_QUERY, 5))
+                .thenThrow(new CannotAcquireLockException("lock timeout"));
+
+        LocationRepositoryImpl repository = new LocationRepositoryImpl(dbInteractions);
+
+        assertThatThrownBy(() -> repository.lockLocation(5))
+                .isInstanceOf(CannotAcquireLockException.class);
     }
 }

--- a/src/test/python/preponderous/viron/services/test_locationService.py
+++ b/src/test/python/preponderous/viron/services/test_locationService.py
@@ -169,6 +169,15 @@ def test_remove_entity_from_location(mock_delete):
     mock_delete.assert_called_with("http://localhost:9999/api/v1/locations/1/entity/1", headers={})
 
 @patch('requests.delete')
+def test_remove_entity_from_location_not_there(mock_delete):
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_delete.return_value = mock_response
+
+    with pytest.raises(Exception, match="No location 1 holding entity 2"):
+        service.remove_entity_from_location(2, 1)
+
+@patch('requests.delete')
 def test_remove_entity_from_current_location(mock_delete):
     mock_response = Mock()
     mock_response.raise_for_status = Mock()


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- `PUT /api/v1/locations/{locationId}/entity/{entityId}/move` refused a move into an occupied location by reading occupancy and then writing on the strength of that read, with no boundary between the two. Two moves into the same empty location both read it empty and both committed, so the collision the endpoint's 409 exists to prevent happened anyway (#203).
- The target location's own row is now locked before its occupancy is read, and the move runs inside a transaction so the lock is held until the write is committed. A second move into the same location waits, then reads the placement the first one left behind and is answered with the 409 it would have received had the two requests arrived in sequence.
- The location row is what gets locked, rather than whatever occupies it, because an empty location has no occupancy rows to lock and emptiness is exactly the state the check depends on. Nothing in the schema settles this the way the primary key on `entity_location.entity_id` settles the placement race in #200: a location is permitted to hold several entities, and `addEntityToLocation` places one without consulting occupancy at all. The question of whether one-entity-per-location should become a real invariant — option 1 of #203 — is left untouched by this change, which only makes the rule this one endpoint already applies hold under concurrency.
- The entity's own placement is locked before the target location, because that is the order `EnvironmentController.deleteEnvironment` acquires the same two locks in — it clears `entity_location` before deleting the locations — and the reverse order would let a move and a cascade delete wait on each other in a cycle. Locking the placement first also keeps the position the grid and adjacency checks are made against from moving underneath them.
- `DELETE /api/v1/locations/{locationId}/entity/{entityId}` answered 500 when the entity named was not placed at the location named, because no row was affected and the failure was reported as a `ServiceException`. It now answers 404, matching the sibling `DELETE /api/v1/locations/entity/{entityId}`, which already handled the equivalent case that way (#210). Its check runs under the same placement lock and transaction, so two removals of the same placement at once do not reintroduce the 500 through the back door.
- `DbInteractions.lock` was added for the locking statements. The existing `queryOne` catches a `SQLException`, logs it, and returns an empty `Optional`, which would have made a lock timeout or a broken deadlock indistinguishable from a row that does not exist — and so would have answered 404 for a location that plainly exists. The new method reports the failure as `CannotAcquireLockException` instead, in the manner `updateReportingDuplicateKey` already reports a duplicate key.
- The OpenAPI spec and `docs/MVP.md` are updated for both endpoints, and the Python client's message for the delete's 404 no longer names only the location, since that answer now covers the placement too.

## Left for a follow-up

Nothing bounds how long a request waits for one of the new locks: the pool size is HikariCP's default and no `lock_timeout` is set. That is a deployment-configuration decision that interacts with the cascade delete's statement-per-row loop, so it is filed as #212 rather than settled here.

## Test plan

- [x] `mvn test -B` — 441 tests, 0 failures (`./mvnw` is not usable in this environment; the system Maven was used, and CI runs `./mvnw test -B` against the same suite).
- [x] `python3 -m pytest` — 108 passed.
- [x] `ConcurrentMoveTest` was confirmed to catch the defect rather than merely to pass: it fails both with `FOR UPDATE` removed from the locking statement and with the lock moved to after the occupancy read, and passes only with the lock in place.
- [x] `TransactionBoundaryWiringTest` covers that both endpoints' `@Transactional` is genuinely applied at runtime, since the locks are worthless without it.
- [x] `DbInteractionsTest` covers that a locking statement reports whether it matched a row and reports a failed statement rather than returning false.
- [x] New `LocationControllerTest` cases cover the lock ordering, a target deleted between the two reads, a placement that cannot be read back after being locked, and both shapes of the delete's new 404.

Closes #203
Closes #210

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).